### PR TITLE
Hotfix/securityanduser

### DIFF
--- a/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
+++ b/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
@@ -65,15 +65,21 @@ public class SecurityConfig {
         // 아이콘, css, js 관련
         // 기본 페이지, css, image, js 하위 폴더에 있는 자료들은 모두 접근 가능, h2-console에 접근 가능
         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**",
+            "/index.html",
             "/login/**",
-            "/v1/nengtul/user/join", "/v1/nengtul/user/login", "/index.html"
+            "/v1/nengtul/user/join",//회원가입
+            "/v1/nengtul/user/login",//로그인
+            "v1/nengtul/user/findpw",//비밀번호 찾기 (비밀번호 재발급)
+            "v1/nengtul/user/findid",//아이디 찾기
+            "v1/nengtul/user/verify/**" //이메일 인증
         ).permitAll()
-        .requestMatchers("/v1/nengtul/user/quit").hasRole("USER") // 회원가입 접근 가능
+        .requestMatchers("/v1/nengtul/user/**").hasRole("USER") // 회원가입 접근 가능
         .requestMatchers("/v1/nengtul/admin/**").hasRole("ADMIN") // 회원가입 접근 가능
-        .anyRequest().permitAll() // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
+        .anyRequest().authenticated() // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
         .and()
         //== 소셜 로그인 설정 ==//
-        .oauth2Login()
+        .oauth2Login().loginPage("/index.html") //권한 오류 발생시 /index.html 로 이동 (테스트용)
+//        .oauth2Login().loginPage("/v1/nengtul/user/login")
         .successHandler(oAuth2LoginSuccessHandler) // 동의하고 계속하기를 눌렀을 때 Handler 설정
         .failureHandler(oAuth2LoginFailureHandler) // 소셜 로그인 실패 시 핸들러 설정
         .userInfoEndpoint().userService(customOAuth2UserService); // customUserService 설정

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -3,6 +3,7 @@ package kr.zb.nengtul.user.controller;
 import java.security.Principal;
 import kr.zb.nengtul.user.entity.dto.UserDetailDto;
 import kr.zb.nengtul.user.entity.dto.UserFindEmailDto;
+import kr.zb.nengtul.user.entity.dto.UserFindPasswordDto;
 import kr.zb.nengtul.user.entity.dto.UserJoinDto;
 import kr.zb.nengtul.user.entity.dto.UserUpdateDto;
 import kr.zb.nengtul.user.service.UserService;
@@ -33,8 +34,8 @@ public class UserController {
     return ResponseEntity.ok(userService.join(userJoinDto));
   }
 
-  //이메일 인증
-  @PutMapping("/verify")
+  //이메일 인증 (이메일에서 링크를 클릭하여 put 요청을 보낼 수 없어서 GET요청으로 처리)
+  @GetMapping("/verify")
   public ResponseEntity<String> verify(@RequestParam String email, @RequestParam String code) {
     userService.verify(email, code);
     return ResponseEntity.ok("인증이 완료되었습니다.");
@@ -55,8 +56,8 @@ public class UserController {
 
   //임시 비밀번호 발급
   @GetMapping("/findpw")
-  public ResponseEntity<String> findPasswordForSendMail(@RequestParam String email) {
-    return ResponseEntity.ok(userService.findPasswordForSendMail(email));
+  public ResponseEntity<String> getNewPassword(@RequestBody UserFindPasswordDto userFindPasswordDto) {
+    return ResponseEntity.ok(userService.getNewPassword(userFindPasswordDto));
   }
 
   //회원 상세보기

--- a/src/main/java/kr/zb/nengtul/user/entity/dto/UserFindPasswordDto.java
+++ b/src/main/java/kr/zb/nengtul/user/entity/dto/UserFindPasswordDto.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserFindPasswordDto {
+  private String email;
   private String name;
   private String phoneNumber;
 }

--- a/src/main/java/kr/zb/nengtul/user/entity/repository/UserRepository.java
+++ b/src/main/java/kr/zb/nengtul/user/entity/repository/UserRepository.java
@@ -10,5 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByName(String name);
   Optional<User> findByRefreshToken(String refreshToken);
   Optional<User> findByProviderTypeAndSocialId(ProviderType providerType, String socialId);
+  Optional<User> findByEmailAndNameAndPhoneNumber(String email, String name, String phoneNumber);
   boolean existsByEmail(String email);
 }

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -195,7 +195,8 @@ public class UserService {
     StringBuilder builder = new StringBuilder();
     //TODO : HTML email 폼 적용 예정
     return builder.append("안녕하세요 ").append(name).append("! 링크를 통해 이메일 인증을 진행해주세요. \n\n")
-        .append("http://localhost:8080/v1/nengtul/user/verify?email=")
+      //.append("http://localhost:8080/v1/nengtul/user/verify?email=") //로컬
+        .append("http://43.200.162.72:8080/v1/nengtul/user/verify?email=") //배포
         .append(email)
         .append("&code=")
         .append(code).toString();

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -14,6 +14,7 @@ import kr.zb.nengtul.global.jwt.JwtTokenProvider;
 import kr.zb.nengtul.user.entity.domain.User;
 import kr.zb.nengtul.user.entity.dto.UserDetailDto;
 import kr.zb.nengtul.user.entity.dto.UserFindEmailDto;
+import kr.zb.nengtul.user.entity.dto.UserFindPasswordDto;
 import kr.zb.nengtul.user.entity.dto.UserJoinDto;
 import kr.zb.nengtul.user.entity.dto.UserUpdateDto;
 import kr.zb.nengtul.user.entity.repository.UserRepository;
@@ -127,24 +128,37 @@ public class UserService {
     return user.getEmail();
   }
 
-  //인증용 이메일 (인증요청시 온 버튼을 어떻게 put으로 보내지??)
-  private String getVerificationEmailBody(String email, String name, String code) {
-    StringBuilder builder = new StringBuilder();
-    return builder.append("안녕하세요 ").append(name).append("! 링크를 통해 이메일 인증을 진행해주세요. \n\n")
-        .append("http://localhost:8080/v1/nengtul/user/verify?email=")
-        .append(email)
-        .append("&code=")
-        .append(code).toString();
+  //가입한 이메일 찾기(아이디 찾기)
+  public String findEmail(UserFindEmailDto userFindEmailDto) {
+    User user = userRepository.findByName(userFindEmailDto.getName())
+        .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+    if (!user.getPhoneNumber().equals(userFindEmailDto.getPhoneNumber())) {
+      throw new CustomException(NOT_FOUND_USER);
+    }
+    return user.getEmail();
   }
 
-  //비밀번호 찾기용 Email
-  private String getPasswordEmailBody(String name, String code) {
-    StringBuilder builder = new StringBuilder();
-    return builder.append("안녕하세요 ").append(name)
-        .append(" 님! 이메일에 작성된 임시 비밀번호를 통해 로그인해주세요. \n\n")
-        .append("임시 비밀번호를 통해 로그인 후 비밀번호를 꼭 변경해주세요. \n\n")
-        .append("임시 비밀번호 : ")
-        .append(code).toString();
+  //임시 비밀번호 발급(비밀번호 찾기)
+  @Transactional
+  public String getNewPassword(UserFindPasswordDto userFindPasswordDto) {
+    //이메일 전송 (이메일, 이름, 휴대폰 번호 부여받음)
+    User user = userRepository.findByEmailAndNameAndPhoneNumber(userFindPasswordDto.getEmail(), userFindPasswordDto.getName(), userFindPasswordDto.getPhoneNumber())
+        .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+
+    String code = RandomStringUtils.random(10, true, true);
+
+    //임시비밀번호 발급 및 이메일 전송 + db에 임시 비밀번호로 저장
+    SendMailForm sendMailForm = SendMailForm.builder()
+        .from("lvet0330@gmail.com")
+        .to(user.getEmail())
+        .subject("냉털 임시 비밀번호 발급 이메일")
+        .text(getPasswordEmailBody( user.getName(), code))
+        .build();
+
+    mailgunClient.sendEmail(sendMailForm);
+    user.setPassword(passwordEncoder.encode(code));
+    userRepository.save(user);
+    return "이메일을 통해 임시 비밀번호가 발급되었습니다. 임시 비밀번호를 통해 로그인해주세요.";
   }
 
   //인증코드 및 시간 설정
@@ -176,38 +190,26 @@ public class UserService {
     changeCustomerValidateEmail(user.getId(), code);
   }
 
-  //가입한 이메일 찾기(아이디 찾기)
-  public String findEmail(UserFindEmailDto userFindEmailDto) {
-    User user = userRepository.findByName(userFindEmailDto.getName())
-        .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
-    if (!user.getPhoneNumber().equals(userFindEmailDto.getPhoneNumber())) {
-      throw new CustomException(NOT_FOUND_USER);
-    }
-    return user.getEmail();
+  //인증용 이메일 (인증요청시 온 버튼을 어떻게 put으로 보내지??)
+  private String getVerificationEmailBody(String email, String name, String code) {
+    StringBuilder builder = new StringBuilder();
+    //TODO : HTML email 폼 적용 예정
+    return builder.append("안녕하세요 ").append(name).append("! 링크를 통해 이메일 인증을 진행해주세요. \n\n")
+        .append("http://localhost:8080/v1/nengtul/user/verify?email=")
+        .append(email)
+        .append("&code=")
+        .append(code).toString();
   }
 
-  //임시 비밀번호 발급
-  @Transactional
-  public String findPasswordForSendMail(String email) {
-    //이메일 전송
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
-    //이메일 verify 진행
-    resetVerify(user.getId());
-    //verify 하면서 임시 비밀번호 발급
-    String code = RandomStringUtils.random(10, true, true);
-
-    SendMailForm sendMailForm = SendMailForm.builder()
-        .from("lvet0330@gmail.com")
-        .to(user.getEmail())
-        .subject("냉털 계정 인증용 이메일")
-        .text(getPasswordEmailBody(user.getName(), code))
-        .build();
-
-    mailgunClient.sendEmail(sendMailForm);
-    changeCustomerValidateEmail(user.getId(), code);
-    user.setPassword(passwordEncoder.encode(code));
-    userRepository.save(user);
-    return "이메일을 통해 임시 비밀번호가 발급되었습니다. 임시 비밀번호를 통해 로그인해주세요.";
+  //비밀번호 찾기용 Email
+  private String getPasswordEmailBody(String name, String code) {
+    StringBuilder builder = new StringBuilder();
+    //TODO : HTML email 폼 적용 예정
+    return builder.append("안녕하세요 ").append(name)
+        .append(" 님! 이메일에 작성된 임시 비밀번호를 통해 로그인해주세요. \n\n")
+        .append("임시 비밀번호를 통해 로그인 후 비밀번호를 꼭 변경해주세요. \n\n")
+        .append("임시 비밀번호 : ")
+        .append(code).toString();
   }
+
 }


### PR DESCRIPTION
    이외의 요청 모든권한 수락 > 인증되었을 경우 수락
    .anyRequest().permitAll() -> .anyRequest().authenticated()

    권한 없을시 index.html 로 이동하도록 수정
    .oauth2Login().loginPage("/index.html")

    임시 비밀번호 발급시 인증이메일도 같이 가는 현상 수정 및, 이메일 제목 수정
    메소드 이름 getNewPassword 로 수정

    임시 비밀번호 발급시, 기존 비밀번호가 임시 비밀번호로 덮어씌워지기 때문에 
      Optional<User> findByEmailAndNameAndPhoneNumber(String email, String name, String phoneNumber);
    추가하여 적용. 3가지가 다 일치할 시에만 임시 비밀번호 발급 및 변경

    이메일 인증시 put 요청으로 받는게 바람직하지만, 이메일에서 링크 클릭시 get요청으로 받아오기 때문에
    GetMapping 적용 (html 이메일 폼 제작시에 put 으로 바꿀예정)

    TODO : html 이메일 폼 제작