### PR TITLE
Feature/servicefixjh

### DIFF
--- a/src/main/java/kr/zb/nengtul/auth/AuthController.java
+++ b/src/main/java/kr/zb/nengtul/auth/AuthController.java
@@ -1,0 +1,16 @@
+package kr.zb.nengtul.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/auth")
+public class AuthController {
+  @GetMapping("/refresh")
+  public ResponseEntity<String> refreshToken (){
+    //access Token 및 refreshToken 발급 과정은 필터에서 진행, 단순 요청을 위한 api\
+    return null;
+  }
+}

--- a/src/main/java/kr/zb/nengtul/auth/AuthController.java
+++ b/src/main/java/kr/zb/nengtul/auth/AuthController.java
@@ -1,16 +1,22 @@
 package kr.zb.nengtul.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AUTH API", description = "리프레시 토큰 API")
 @RestController
 @RequestMapping("/v1/auth")
 public class AuthController {
+
   @GetMapping("/refresh")
-  public ResponseEntity<String> refreshToken (){
+  @Operation(summary = "토큰 리프레시", description = "기능은 필터에서 동작하고 refresh 요청주소로 사용하기 위해 작성하였습니다.")
+  public ResponseEntity<String> refreshToken() {
     //access Token 및 refreshToken 발급 과정은 필터에서 진행, 단순 요청을 위한 api\
     return null;
   }
 }
+

--- a/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
+++ b/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                 "/h2-console/**",
                 "/index.html",
                 "/login/**",
+                "/v1/auth/**",
                 "/v1/user/join",//회원가입
                 "/v1/user/login",//로그인
                 "/v1/user/findpw",//비밀번호 찾기 (비밀번호 재발급)

--- a/src/main/java/kr/zb/nengtul/global/handler/LoginSuccessHandler.java
+++ b/src/main/java/kr/zb/nengtul/global/handler/LoginSuccessHandler.java
@@ -35,15 +35,6 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
           user.updateRefreshToken(refreshToken);
           userRepository.saveAndFlush(user);
         });
-
-    response.setStatus(HttpStatus.OK.value());
-    response.setCharacterEncoding("UTF-8");
-    response.setContentType("application/json;charset=UTF-8");
-
-    String successMessage = "{\"email\": \"" + email +
-        "\", \"AccessToken\": \"" + accessToken +
-        "\", \"refreshToken\": \"" + refreshToken + "\"}";
-    response.getWriter().write(successMessage);
   }
 
   private String extractUsername(Authentication authentication) {

--- a/src/main/java/kr/zb/nengtul/global/jwt/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/kr/zb/nengtul/global/jwt/JwtAuthenticationProcessingFilter.java
@@ -64,9 +64,13 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     userRepository.findByRefreshToken(refreshToken)
         .ifPresent(user -> {
           String reIssuedRefreshToken = reIssueRefreshToken(user);
-          jwtTokenProvider.sendAccessAndRefreshToken(response,
-              jwtTokenProvider.createAccessToken(user.getEmail()),
-              reIssuedRefreshToken);
+          try {
+            jwtTokenProvider.sendAccessAndRefreshToken(response,
+                jwtTokenProvider.createAccessToken(user.getEmail()),
+                reIssuedRefreshToken);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
         });
   }
 

--- a/src/main/java/kr/zb/nengtul/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/zb/nengtul/global/jwt/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.Date;
 
 import java.util.Optional;
@@ -17,6 +18,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -79,11 +81,19 @@ public class JwtTokenProvider {
   }
 
   public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken,
-      String refreshToken) {
+      String refreshToken) throws IOException {
     response.setStatus(HttpServletResponse.SC_OK);
 
     setAccessTokenHeader(response, "Bearer " + accessToken);
     setRefreshTokenHeader(response, "Bearer " + refreshToken);
+
+    response.setStatus(HttpStatus.OK.value());
+    response.setCharacterEncoding("UTF-8");
+    response.setContentType("application/json;charset=UTF-8");
+
+    String successMessage = "{\"AccessToken\": \"" + accessToken +
+        "\", \"refreshToken\": \"" + refreshToken + "\"}";
+    response.getWriter().write(successMessage);
     log.info("Access Token, Refresh Token 헤더 설정 완료");
   }
 

--- a/src/main/java/kr/zb/nengtul/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/kr/zb/nengtul/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -41,14 +41,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             user.updateRefreshToken(refreshToken);
             userRepository.saveAndFlush(user);
           });
-      response.setStatus(HttpStatus.OK.value());
-      response.setCharacterEncoding("UTF-8");
-      response.setContentType("application/json;charset=UTF-8");
-
-      String successMessage = "{\"AccessToken\": \"" + accessToken +
-          "\", \"refreshToken\": \"" + refreshToken + "\"}";
-      response.getWriter().write(successMessage);
-      jwtTokenProvider.sendAccessAndRefreshToken(response, accessToken, null);
+//      jwtTokenProvider.sendAccessAndRefreshToken(response, accessToken, null);
       loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
     } catch (CustomException e) {
       throw new CustomException(NOT_FOUND_USER);
@@ -56,7 +49,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
   }
 
-  private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) {
+  private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User)
+      throws IOException {
     String accessToken = jwtTokenProvider.createAccessToken(oAuth2User.getEmail());
     String refreshToken = jwtTokenProvider.createRefreshToken();
     response.addHeader(jwtTokenProvider.getAccessHeader(), "Bearer " + accessToken);

--- a/src/main/java/kr/zb/nengtul/notice/controller/NoticeController.java
+++ b/src/main/java/kr/zb/nengtul/notice/controller/NoticeController.java
@@ -65,7 +65,8 @@ public class NoticeController {
   @Operation(summary = "공지사항 조회", description = "공지사항 목록을 전체 조회합니다. (Pageable 적용)")
   @GetMapping("/list")
   public ResponseEntity<Page<NoticeListDto>> getList(Pageable pageable) {
-    return ResponseEntity.ok(noticeService.getList(pageable));
+    return ResponseEntity.ok(
+        noticeService.getList(pageable).map(NoticeListDto::buildNoticeListDto));
   }
 
   //상세 조회
@@ -73,6 +74,7 @@ public class NoticeController {
   @GetMapping("/list/{noticeId}")
   public ResponseEntity<NoticeDetailDto> getDetails(
       @Parameter(name = "id)", description = "공지사항 ID") @PathVariable Long noticeId) {
-    return ResponseEntity.ok(noticeService.getDetails(noticeId));
+    return ResponseEntity.ok(
+        NoticeDetailDto.buildNoticeDetailDto(noticeService.getDetails(noticeId)));
   }
 }

--- a/src/main/java/kr/zb/nengtul/shareboard/controller/ShareBoardController.java
+++ b/src/main/java/kr/zb/nengtul/shareboard/controller/ShareBoardController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
+import java.util.stream.Collectors;
 import kr.zb.nengtul.shareboard.domain.dto.ShareBoardDto;
 import kr.zb.nengtul.shareboard.domain.dto.ShareBoardListDto;
 import kr.zb.nengtul.shareboard.service.ShareBoardService;
@@ -49,7 +50,9 @@ public class ShareBoardController {
       @Parameter(name = "lon", description = "위도") @RequestParam double lon,
       @Parameter(name = "range", description = "반경 범위") @RequestParam double range,
       @Parameter(name = "closed", description = "완료 여부") @RequestParam(required = false) Boolean closed) {
-    return ResponseEntity.ok(shareBoardService.getList(lat, lon, range, closed));
+    return ResponseEntity.ok(shareBoardService.getList(lat, lon, range, closed).stream()
+        .map(ShareBoardListDto::buildShareBoardListDto)
+        .collect(Collectors.toList()));
   }
 
   //수정

--- a/src/main/java/kr/zb/nengtul/shareboard/service/ShareBoardService.java
+++ b/src/main/java/kr/zb/nengtul/shareboard/service/ShareBoardService.java
@@ -15,6 +15,7 @@ import kr.zb.nengtul.shareboard.domain.entity.ShareBoard;
 import kr.zb.nengtul.shareboard.domain.repository.ShareBoardRepository;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.domain.repository.UserRepository;
+import kr.zb.nengtul.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,11 +27,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShareBoardService {
 
   private final UserRepository userRepository;
+  private final UserService userService;
   private final ShareBoardRepository shareBoardRepository;
 
   @Transactional
   public void create(ShareBoardDto shareBoardDto, Principal principal) {
-    User user = findUserByEmail(principal.getName());
+    User user = userService.findUserByEmail(principal.getName());
     if (!user.isEmailVerifiedYn()) {
       throw new CustomException(NOT_VERIFY_EMAIL);
     }
@@ -52,7 +54,7 @@ public class ShareBoardService {
   public void update(Long id, ShareBoardDto shareBoardDto, Principal principal) {
     ShareBoard shareBoard = shareBoardRepository.findById(id)
         .orElseThrow(() -> new CustomException(NOT_FOUND_SHARE_BOARD));
-    User user = findUserByEmail(principal.getName());
+    User user = userService.findUserByEmail(principal.getName());
     if (shareBoard.getUser() != user) {
       throw new CustomException(NO_PERMISSION);
     }
@@ -68,7 +70,7 @@ public class ShareBoardService {
   public void delete(Long id, Principal principal) {
     ShareBoard shareBoard = shareBoardRepository.findById(id)
         .orElseThrow(() -> new CustomException(NOT_FOUND_SHARE_BOARD));
-    User user = findUserByEmail(principal.getName());
+    User user = userService.findUserByEmail(principal.getName());
     if (shareBoard.getUser() != user) {
       throw new CustomException(NO_PERMISSION);
     }
@@ -76,7 +78,7 @@ public class ShareBoardService {
   }
 
   @Transactional
-  public List<ShareBoardListDto> getList(double lat, double lon, double range, Boolean closed) {
+  public List<ShareBoard> getList(double lat, double lon, double range, Boolean closed) {
     List<ShareBoard> shareBoardList;
     if (closed == null) {
       shareBoardList = shareBoardRepository.findByLatBetweenAndLonBetween(
@@ -87,14 +89,7 @@ public class ShareBoardService {
           lat - range, lat + range, lon - range, lon + range, closed);
 
     }
-    return shareBoardList.stream()
-        .map(ShareBoardListDto::buildShareBoardListDto)
-        .collect(Collectors.toList());
-  }
-
-  public User findUserByEmail(String email) {
-    return userRepository.findByEmail(email)
-        .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+    return shareBoardList;
   }
 
 }

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -66,7 +66,8 @@ public class UserController {
   @PostMapping("/findid")
   public ResponseEntity<UserFindEmailResDto> findEmail(
       @RequestBody UserFindEmailReqDto userFindEmailReqDto) {
-    return ResponseEntity.ok(userService.findEmail(userFindEmailReqDto));
+    return ResponseEntity.ok(
+        new UserFindEmailResDto(userService.findEmail(userFindEmailReqDto).getEmail()));
   }
 
   //임시 비밀번호 발급
@@ -82,7 +83,8 @@ public class UserController {
   @Operation(summary = "회원 상세보기", description = "토큰을 통해 회원 상세 정보를 받습니다.")
   @GetMapping("/detail")
   public ResponseEntity<UserDetailDto> getUserDetail(Principal principal) {
-    return ResponseEntity.ok(userService.getUserDetail(principal));
+    return ResponseEntity.ok(
+        UserDetailDto.buildUserDetailDto(userService.findUserByEmail(principal.getName())));
   }
 
   //회원 탈퇴(상세보기 페이지에서 진행)

--- a/src/main/java/kr/zb/nengtul/user/domain/dto/UserDetailDto.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/dto/UserDetailDto.java
@@ -18,6 +18,7 @@ public class UserDetailDto {
   private String nickname;
   private String password; //비밀번호 변경을 위해서
   private String phoneNumber;
+  private String profileImageUrl;
   private ProviderType providerTYpe;
   private String address;
   private String addressDetail;
@@ -30,6 +31,7 @@ public class UserDetailDto {
         .nickname(user.getNickname())
         .password(user.getPassword())
         .phoneNumber(user.getPhoneNumber())
+        .profileImageUrl(user.getProfileImageUrl())
         .providerTYpe(user.getProviderType())
         .address(user.getAddress())
         .addressDetail(user.getAddressDetail())

--- a/src/main/java/kr/zb/nengtul/user/domain/dto/UserFindEmailResDto.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/dto/UserFindEmailResDto.java
@@ -14,12 +14,6 @@ import lombok.Setter;
 public class UserFindEmailResDto {
 
   private String email;
-
-  public static UserFindEmailResDto buildUserFindEmailResDto(String email) {
-    return UserFindEmailResDto.builder()
-        .email(email)
-        .build();
-  }
 }
 
 

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -37,7 +37,6 @@ public class UserService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final MailgunClient mailgunClient;
-  private final JwtTokenProvider jwtTokenProvider;
 
   //회원가입 및 이메일 인증 발송
   @Transactional
@@ -78,13 +77,6 @@ public class UserService {
     user.setEmailVerifiedYn(true);
   }
 
-  //유저 상세보기
-  public UserDetailDto getUserDetail(Principal principal) {
-    User user = findUserByEmail(principal.getName());
-
-    return UserDetailDto.buildUserDetailDto(user);
-  }
-
   //회원 탈퇴
   @Transactional
   public void quit(Principal principal) {
@@ -117,11 +109,10 @@ public class UserService {
   }
 
   //가입한 이메일 찾기(아이디 찾기)
-  public UserFindEmailResDto findEmail(UserFindEmailReqDto userFindEmailReqDto) {
-    User user = userRepository.findByNameAndPhoneNumber(userFindEmailReqDto.getName(),
+  public User findEmail(UserFindEmailReqDto userFindEmailReqDto) {
+    return userRepository.findByNameAndPhoneNumber(userFindEmailReqDto.getName(),
             userFindEmailReqDto.getPhoneNumber())
         .orElseThrow(() -> new CustomException(NO_CONTENT));
-    return UserFindEmailResDto.buildUserFindEmailResDto(user.getEmail());
   }
 
   //임시 비밀번호 발급(비밀번호 찾기)


### PR DESCRIPTION
## 7/28 리뷰 기반 수정 및 refresh API 추가

- 서비스 코드에서 dto를 return 하여 바로 응답에 담는 방식에서 
사용하는 객체를 return 시켜 controller에서 dto를 사용해 가공하는 방식으로 변경

- 유저 상세보기시 유저 프로필사진이 들어가있지 않아 추가

- Refresh API
로그인 성공시 sendAccessAndRefreshToken를 호출하게 되는데 이곳에서 토큰 response 로 내려주도록 수정.

  토큰이 만료되고 난 후에 refreshToken 과 accessToken을 헤더에 담아
  v1/auth/refresh 요청을 보내면 필터에서 토큰을 재생성하여 response에 담아주는 방식으로 변경

  v1/auth/refresh 는 권한 오류가 발생하였을 때 두 개의 토큰을 담아서 단순 요청을 보내기 위한 빈 껍데기 API

```
    response.setStatus(HttpStatus.OK.value());
    response.setCharacterEncoding("UTF-8");
    response.setContentType("application/json;charset=UTF-8");

    String successMessage = "{\"AccessToken\": \"" + accessToken +
        "\", \"refreshToken\": \"" + refreshToken + "\"}";
    response.getWriter().write(successMessage);
```