### PR TITLE
Feature/uservalidation

### DIFF
--- a/src/main/java/kr/zb/nengtul/global/exception/ErrorCode.java
+++ b/src/main/java/kr/zb/nengtul/global/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
   // 유저
   ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 사용자입니다."),
   ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 이메일입니다."),
+  ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 닉네임입니다."),
+  ALREADY_EXIST_PHONENUMBER(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 휴대폰 번호입니다."),
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
   ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료된 사용자입니다."),
   WRONG_VERIFY_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다."),

--- a/src/main/java/kr/zb/nengtul/notice/controller/NoticeController.java
+++ b/src/main/java/kr/zb/nengtul/notice/controller/NoticeController.java
@@ -35,46 +35,46 @@ public class NoticeController {
   //생성
   @Operation(summary = "공지사항 작성", description = "토큰을 통해 관리자여부를 확인 후 공지사항을 작성합니다.")
   @PostMapping
-  public ResponseEntity<Void> create(@RequestBody @Valid NoticeReqDto noticeReqDto,
+  public ResponseEntity<Void> createNotice(@RequestBody @Valid NoticeReqDto noticeReqDto,
       Principal principal) {
-    noticeService.create(noticeReqDto, principal);
+    noticeService.createNotice(noticeReqDto, principal);
     return ResponseEntity.ok(null);
   }
 
   //수정
   @Operation(summary = "공지사항 수정", description = "토큰을 통해 관리자여부, 작성자 여부를 확인 후 공지사항을 수정합니다.")
   @PutMapping("/{noticeId}")
-  public ResponseEntity<Void> update(
+  public ResponseEntity<Void> updateNotice(
       @Parameter(name = "email", description = "공지사항 ID") @PathVariable Long noticeId,
       @RequestBody @Valid NoticeReqDto noticeReqDto, Principal principal) {
-    noticeService.update(noticeId, noticeReqDto, principal);
+    noticeService.updateNotice(noticeId, noticeReqDto, principal);
     return ResponseEntity.ok(null);
   }
 
   //삭제
   @Operation(summary = "공지사항 삭제", description = "토큰을 통해 관리자여부, 작성자 여부를 확인 후 공지사항을 삭제합니다.")
   @DeleteMapping("/{noticeId}")
-  public ResponseEntity<Void> delete(
+  public ResponseEntity<Void> deleteNotice(
       @Parameter(name = "id)", description = "공지사항 ID") @PathVariable Long noticeId,
       Principal principal) {
-    noticeService.delete(noticeId, principal);
+    noticeService.deleteNotice(noticeId, principal);
     return ResponseEntity.ok(null);
   }
 
   //전체 조회
   @Operation(summary = "공지사항 조회", description = "공지사항 목록을 전체 조회합니다. (Pageable 적용)")
   @GetMapping("/list")
-  public ResponseEntity<Page<NoticeListDto>> getList(Pageable pageable) {
+  public ResponseEntity<Page<NoticeListDto>> getNoticeList(Pageable pageable) {
     return ResponseEntity.ok(
-        noticeService.getList(pageable).map(NoticeListDto::buildNoticeListDto));
+        noticeService.getNoticeList(pageable).map(NoticeListDto::buildNoticeListDto));
   }
 
   //상세 조회
   @Operation(summary = "공지사항 상세", description = "공지사항을 상세 조회합니다.")
   @GetMapping("/list/{noticeId}")
-  public ResponseEntity<NoticeDetailDto> getDetails(
+  public ResponseEntity<NoticeDetailDto> getNoticeDetails(
       @Parameter(name = "id)", description = "공지사항 ID") @PathVariable Long noticeId) {
     return ResponseEntity.ok(
-        NoticeDetailDto.buildNoticeDetailDto(noticeService.getDetails(noticeId)));
+        NoticeDetailDto.buildNoticeDetailDto(noticeService.getNoticeDetails(noticeId)));
   }
 }

--- a/src/main/java/kr/zb/nengtul/notice/service/NoticeService.java
+++ b/src/main/java/kr/zb/nengtul/notice/service/NoticeService.java
@@ -1,18 +1,14 @@
 package kr.zb.nengtul.notice.service;
 
 import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_NOTICE;
-import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_USER;
 import static kr.zb.nengtul.global.exception.ErrorCode.NO_PERMISSION;
 
 import java.security.Principal;
 import kr.zb.nengtul.global.exception.CustomException;
 import kr.zb.nengtul.notice.domain.entity.Notice;
-import kr.zb.nengtul.notice.domain.dto.NoticeDetailDto;
-import kr.zb.nengtul.notice.domain.dto.NoticeListDto;
 import kr.zb.nengtul.notice.domain.dto.NoticeReqDto;
 import kr.zb.nengtul.notice.domain.repository.NoticeRepository;
 import kr.zb.nengtul.user.domain.entity.User;
-import kr.zb.nengtul.user.domain.repository.UserRepository;
 import kr.zb.nengtul.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +26,7 @@ public class NoticeService {
   private final NoticeRepository noticeRepository;
 
   @Transactional
-  public void create(NoticeReqDto noticeReqDto, Principal principal) {
+  public void createNotice(NoticeReqDto noticeReqDto, Principal principal) {
     User user = userService.findUserByEmail(principal.getName());
     Notice notice = Notice.builder()
         .title(noticeReqDto.getTitle())
@@ -43,7 +39,7 @@ public class NoticeService {
   }
 
   @Transactional
-  public void update(Long noticeId, NoticeReqDto noticeReqDto, Principal principal) {
+  public void updateNotice(Long noticeId, NoticeReqDto noticeReqDto, Principal principal) {
     User user = userService.findUserByEmail(principal.getName());
     Notice notice = noticeRepository.findById(noticeId)
         .orElseThrow(() -> new CustomException(NOT_FOUND_NOTICE));
@@ -61,7 +57,7 @@ public class NoticeService {
 
 
   @Transactional
-  public void delete(Long noticeId, Principal principal) {
+  public void deleteNotice(Long noticeId, Principal principal) {
     User user = userService.findUserByEmail(principal.getName());
     Notice notice = noticeRepository.findById(noticeId)
         .orElseThrow(() -> new CustomException(NOT_FOUND_NOTICE));
@@ -72,12 +68,12 @@ public class NoticeService {
     }
   }
 
-  public Page<Notice> getList(Pageable pageable) {
+  public Page<Notice> getNoticeList(Pageable pageable) {
     return noticeRepository.findAll(pageable);
   }
 
   @Transactional
-  public Notice getDetails(Long noticeId) {
+  public Notice getNoticeDetails(Long noticeId) {
     Notice notice = noticeRepository.findById(noticeId)
         .orElseThrow(() -> new CustomException(NOT_FOUND_NOTICE));
     notice.setViewCount(notice.getViewCount() + 1);

--- a/src/main/java/kr/zb/nengtul/shareboard/controller/ShareBoardController.java
+++ b/src/main/java/kr/zb/nengtul/shareboard/controller/ShareBoardController.java
@@ -35,9 +35,9 @@ public class ShareBoardController {
   //생성
   @Operation(summary = "게시글 작성", description = "게시글을 작성합니다.")
   @PostMapping
-  public ResponseEntity<Void> create(@RequestBody @Valid ShareBoardDto shareBoardDto,
+  public ResponseEntity<Void> createShareBoard(@RequestBody @Valid ShareBoardDto shareBoardDto,
       Principal principal) {
-    shareBoardService.create(shareBoardDto, principal);
+    shareBoardService.createShareBoard(shareBoardDto, principal);
     return ResponseEntity.ok(null);
   }
 
@@ -45,12 +45,12 @@ public class ShareBoardController {
   @Operation(summary = "나눔 게시물 조회", description = "내 위치 주변 나눔 게시물을 조회합니다."
       + "closed는 필수가 아니며 기입하지 않을 시 모든 상태에 대한 값이 반환되며, true = 거래완료 , false = 거래대기 상태의 게시물을 가져옵니다.")
   @GetMapping
-  public ResponseEntity<List<ShareBoardListDto>> getList(
+  public ResponseEntity<List<ShareBoardListDto>> getShareBoardList(
       @Parameter(name = "lat", description = "경도") @RequestParam double lat,
       @Parameter(name = "lon", description = "위도") @RequestParam double lon,
       @Parameter(name = "range", description = "반경 범위") @RequestParam double range,
       @Parameter(name = "closed", description = "완료 여부") @RequestParam(required = false) Boolean closed) {
-    return ResponseEntity.ok(shareBoardService.getList(lat, lon, range, closed).stream()
+    return ResponseEntity.ok(shareBoardService.getShareBoardList(lat, lon, range, closed).stream()
         .map(ShareBoardListDto::buildShareBoardListDto)
         .collect(Collectors.toList()));
   }
@@ -58,20 +58,20 @@ public class ShareBoardController {
   //수정
   @Operation(summary = "게시글 수정", description = "토큰을 통해 유저를 조회하고, 게시물 ID를 통해 유저 ID를 조회하여 비교 후 글의 작성자인 경우에 게시물을 수정할 수 있습니다.")
   @PutMapping("/{id}")
-  public ResponseEntity<Void> create(
+  public ResponseEntity<Void> updateShareBoard(
       @Parameter(name = "id", description = "게시물 ID") @PathVariable Long id,
       @RequestBody @Valid ShareBoardDto shareBoardDto,
       Principal principal) {
-    shareBoardService.update(id, shareBoardDto, principal);
+    shareBoardService.updateShareBoard(id, shareBoardDto, principal);
     return ResponseEntity.ok(null);
   }
 
   //삭제
   @Operation(summary = "게시글 삭제", description = "토큰을 통해 유저를 조회하고, 게시물 ID를 통해 유저 ID를 조회하여 비교 후 글의 작성자인 경우에 게시물을 삭제할 수 있습니다.")
   @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(
+  public ResponseEntity<Void> deleteShareBoard(
       @Parameter(name = "id", description = "게시물 ID") @PathVariable Long id, Principal principal) {
-    shareBoardService.delete(id, principal);
+    shareBoardService.deleteShareBoard(id, principal);
     return ResponseEntity.ok(null);
   }
 }

--- a/src/main/java/kr/zb/nengtul/shareboard/service/ShareBoardService.java
+++ b/src/main/java/kr/zb/nengtul/shareboard/service/ShareBoardService.java
@@ -1,16 +1,13 @@
 package kr.zb.nengtul.shareboard.service;
 
 import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_SHARE_BOARD;
-import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_USER;
 import static kr.zb.nengtul.global.exception.ErrorCode.NOT_VERIFY_EMAIL;
 import static kr.zb.nengtul.global.exception.ErrorCode.NO_PERMISSION;
 
 import java.security.Principal;
 import java.util.List;
-import java.util.stream.Collectors;
 import kr.zb.nengtul.global.exception.CustomException;
 import kr.zb.nengtul.shareboard.domain.dto.ShareBoardDto;
-import kr.zb.nengtul.shareboard.domain.dto.ShareBoardListDto;
 import kr.zb.nengtul.shareboard.domain.entity.ShareBoard;
 import kr.zb.nengtul.shareboard.domain.repository.ShareBoardRepository;
 import kr.zb.nengtul.user.domain.entity.User;
@@ -31,7 +28,7 @@ public class ShareBoardService {
   private final ShareBoardRepository shareBoardRepository;
 
   @Transactional
-  public void create(ShareBoardDto shareBoardDto, Principal principal) {
+  public void createShareBoard(ShareBoardDto shareBoardDto, Principal principal) {
     User user = userService.findUserByEmail(principal.getName());
     if (!user.isEmailVerifiedYn()) {
       throw new CustomException(NOT_VERIFY_EMAIL);
@@ -51,7 +48,7 @@ public class ShareBoardService {
   }
 
   @Transactional
-  public void update(Long id, ShareBoardDto shareBoardDto, Principal principal) {
+  public void updateShareBoard(Long id, ShareBoardDto shareBoardDto, Principal principal) {
     ShareBoard shareBoard = shareBoardRepository.findById(id)
         .orElseThrow(() -> new CustomException(NOT_FOUND_SHARE_BOARD));
     User user = userService.findUserByEmail(principal.getName());
@@ -67,7 +64,7 @@ public class ShareBoardService {
   }
 
   @Transactional
-  public void delete(Long id, Principal principal) {
+  public void deleteShareBoard(Long id, Principal principal) {
     ShareBoard shareBoard = shareBoardRepository.findById(id)
         .orElseThrow(() -> new CustomException(NOT_FOUND_SHARE_BOARD));
     User user = userService.findUserByEmail(principal.getName());
@@ -78,7 +75,7 @@ public class ShareBoardService {
   }
 
   @Transactional
-  public List<ShareBoard> getList(double lat, double lon, double range, Boolean closed) {
+  public List<ShareBoard> getShareBoardList(double lat, double lon, double range, Boolean closed) {
     List<ShareBoard> shareBoardList;
     if (closed == null) {
       shareBoardList = shareBoardRepository.findByLatBetweenAndLonBetween(

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -98,8 +98,9 @@ public class UserController {
   //회원 정보 수정(상세보기 페이지에서 진행)
   @Operation(summary = "회원 정보 수정", description = "토큰을 통해 회원을 인식하고, 회원에 대한 정보를 수정합니다.")
   @PutMapping("/detail")
-  public ResponseEntity<String> updateUser(Principal principal,
+  public ResponseEntity<Void> updateUser(Principal principal,
       @RequestBody @Valid UserUpdateDto userUpdateDto) {
-    return ResponseEntity.ok(userService.updateUser(principal, userUpdateDto));
+    userService.updateUser(principal, userUpdateDto);
+    return ResponseEntity.ok(null);
   }
 }

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -37,18 +37,18 @@ public class UserController {
   //회원가입
   @Operation(summary = "회원가입", description = "회원가입 요청을 보냅니다.")
   @PostMapping("/join")
-  public ResponseEntity<Void> join(@RequestBody @Valid UserJoinDto userJoinDto) {
-    userService.join(userJoinDto);
+  public ResponseEntity<Void> joinUser(@RequestBody @Valid UserJoinDto userJoinDto) {
+    userService.joinUser(userJoinDto);
     return ResponseEntity.ok(null);
   }
 
   //이메일 인증 (이메일에서 링크를 클릭하여 put 요청을 보낼 수 없어서 GET요청으로 처리)
   @Operation(summary = "이메일 인증", description = "이메일을 통해 보낸 링크 클릭시 인증이 진행됩니다.")
   @GetMapping("/verify")
-  public ResponseEntity<Void> verify(
+  public ResponseEntity<Void> verifyEmail(
       @Parameter(name = "email", description = "이메일") @RequestParam String email,
       @Parameter(name = "code", description = "인증 코드") @RequestParam String code) {
-    userService.verify(email, code);
+    userService.verifyEmail(email, code);
     return ResponseEntity.ok(null);
   }
 
@@ -90,16 +90,16 @@ public class UserController {
   //회원 탈퇴(상세보기 페이지에서 진행)
   @Operation(summary = "회원 탈퇴", description = "토큰을 통해 회원 탈퇴 요청을 보냅니다.")
   @DeleteMapping("/detail")
-  public ResponseEntity<Void> quit(Principal principal) {
-    userService.quit(principal);
+  public ResponseEntity<Void> quitUser(Principal principal) {
+    userService.quitUser(principal);
     return ResponseEntity.ok(null);
   }
 
   //회원 정보 수정(상세보기 페이지에서 진행)
   @Operation(summary = "회원 정보 수정", description = "토큰을 통해 회원을 인식하고, 회원에 대한 정보를 수정합니다.")
   @PutMapping("/detail")
-  public ResponseEntity<String> update(Principal principal,
+  public ResponseEntity<String> updateUser(Principal principal,
       @RequestBody @Valid UserUpdateDto userUpdateDto) {
-    return ResponseEntity.ok(userService.update(principal, userUpdateDto));
+    return ResponseEntity.ok(userService.updateUser(principal, userUpdateDto));
   }
 }

--- a/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.UniqueElements;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
@@ -68,11 +68,11 @@ public class User extends BaseTimeEntity {
   private String refreshToken; // 리프레시 토큰
 
   @JsonBackReference
-  @OneToMany(cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
   private List<Notice> noticeList;
 
   @JsonBackReference
-  @OneToMany
+  @OneToMany(mappedBy = "user")
   private List<ShareBoard> shareBoardList;
 
   @Builder

--- a/src/main/java/kr/zb/nengtul/user/domain/repository/UserRepository.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/repository/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmailAndNameAndPhoneNumber(String email, String name, String phoneNumber);
 
   boolean existsByEmail(String email);
+  boolean existsByNickname(String nickname);
+  boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -1,6 +1,8 @@
 package kr.zb.nengtul.user.service;
 
 import static kr.zb.nengtul.global.exception.ErrorCode.ALREADY_EXIST_EMAIL;
+import static kr.zb.nengtul.global.exception.ErrorCode.ALREADY_EXIST_NICKNAME;
+import static kr.zb.nengtul.global.exception.ErrorCode.ALREADY_EXIST_PHONENUMBER;
 import static kr.zb.nengtul.global.exception.ErrorCode.ALREADY_VERIFIED;
 import static kr.zb.nengtul.global.exception.ErrorCode.EXPIRED_CODE;
 import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_USER;
@@ -41,11 +43,15 @@ public class UserService {
   //회원가입 및 이메일 인증 발송
   @Transactional
   public void join(UserJoinDto userJoinDto) {
-    // 이메일 중복 확인
+    // validation
     if (userRepository.existsByEmail(userJoinDto.getEmail())) {
       throw new CustomException(ALREADY_EXIST_EMAIL);
     } else if (userJoinDto.getPassword() == null || userJoinDto.getPassword().length() < 8) {
       throw new CustomException(SHORT_PASSWORD);
+    } else if (userRepository.existsByNickname(userJoinDto.getNickname())) {
+      throw new CustomException(ALREADY_EXIST_NICKNAME);
+    } else if (userRepository.existsByPhoneNumber(userJoinDto.getPhoneNumber())) {
+      throw new CustomException(ALREADY_EXIST_PHONENUMBER);
     }
 
     User user = User.builder()
@@ -92,6 +98,10 @@ public class UserService {
 
     if (userUpdateDto.getPassword() == null || userUpdateDto.getPassword().length() < 8) {
       throw new CustomException(SHORT_PASSWORD);
+    } else if (userRepository.existsByNickname(userUpdateDto.getNickname())) {
+      throw new CustomException(ALREADY_EXIST_NICKNAME);
+    } else if (userRepository.existsByPhoneNumber(userUpdateDto.getPhoneNumber())) {
+      throw new CustomException(ALREADY_EXIST_PHONENUMBER);
     }
 
     String updateProfileImageUrl =

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -13,10 +13,7 @@ import static kr.zb.nengtul.global.exception.ErrorCode.WRONG_VERIFY_CODE;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import kr.zb.nengtul.global.exception.CustomException;
-import kr.zb.nengtul.global.jwt.JwtTokenProvider;
-import kr.zb.nengtul.user.domain.dto.UserDetailDto;
 import kr.zb.nengtul.user.domain.dto.UserFindEmailReqDto;
-import kr.zb.nengtul.user.domain.dto.UserFindEmailResDto;
 import kr.zb.nengtul.user.domain.dto.UserFindPasswordDto;
 import kr.zb.nengtul.user.domain.dto.UserJoinDto;
 import kr.zb.nengtul.user.domain.dto.UserUpdateDto;
@@ -42,7 +39,7 @@ public class UserService {
 
   //회원가입 및 이메일 인증 발송
   @Transactional
-  public void join(UserJoinDto userJoinDto) {
+  public void joinUser(UserJoinDto userJoinDto) {
     // validation
     if (userRepository.existsByEmail(userJoinDto.getEmail())) {
       throw new CustomException(ALREADY_EXIST_EMAIL);
@@ -71,7 +68,7 @@ public class UserService {
 
   //이메일 인증
   @Transactional
-  public void verify(String email, String code) {
+  public void verifyEmail(String email, String code) {
     User user = findUserByEmail(email);
     if (user.isEmailVerifiedYn()) {
       throw new CustomException(ALREADY_VERIFIED);
@@ -85,7 +82,7 @@ public class UserService {
 
   //회원 탈퇴
   @Transactional
-  public void quit(Principal principal) {
+  public void quitUser(Principal principal) {
     User user = findUserByEmail(principal.getName());
 
     userRepository.deleteById(user.getId());
@@ -93,7 +90,7 @@ public class UserService {
 
   //회원 정보 수정
   @Transactional
-  public String update(Principal principal, UserUpdateDto userUpdateDto) {
+  public String updateUser(Principal principal, UserUpdateDto userUpdateDto) {
     User user = findUserByEmail(principal.getName());
 
     if (userUpdateDto.getPassword() == null || userUpdateDto.getPassword().length() < 8) {

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -43,8 +43,6 @@ public class UserService {
     // validation
     if (userRepository.existsByEmail(userJoinDto.getEmail())) {
       throw new CustomException(ALREADY_EXIST_EMAIL);
-    } else if (userJoinDto.getPassword() == null || userJoinDto.getPassword().length() < 8) {
-      throw new CustomException(SHORT_PASSWORD);
     } else if (userRepository.existsByNickname(userJoinDto.getNickname())) {
       throw new CustomException(ALREADY_EXIST_NICKNAME);
     } else if (userRepository.existsByPhoneNumber(userJoinDto.getPhoneNumber())) {
@@ -90,14 +88,18 @@ public class UserService {
 
   //회원 정보 수정
   @Transactional
-  public String updateUser(Principal principal, UserUpdateDto userUpdateDto) {
+  public void updateUser(Principal principal, UserUpdateDto userUpdateDto) {
     User user = findUserByEmail(principal.getName());
 
-    if (userUpdateDto.getPassword() == null || userUpdateDto.getPassword().length() < 8) {
-      throw new CustomException(SHORT_PASSWORD);
-    } else if (userRepository.existsByNickname(userUpdateDto.getNickname())) {
+    // 닉네임 중복 체크
+    if (!user.getNickname().equals(userUpdateDto.getNickname()) && userRepository.existsByNickname(
+        userUpdateDto.getNickname())) {
       throw new CustomException(ALREADY_EXIST_NICKNAME);
-    } else if (userRepository.existsByPhoneNumber(userUpdateDto.getPhoneNumber())) {
+    }
+
+    // 휴대폰 번호 중복 체크
+    if (!user.getPhoneNumber().equals(userUpdateDto.getPhoneNumber())
+        && userRepository.existsByPhoneNumber(userUpdateDto.getPhoneNumber())) {
       throw new CustomException(ALREADY_EXIST_PHONENUMBER);
     }
 
@@ -112,7 +114,6 @@ public class UserService {
     user.setProfileImageUrl(updateProfileImageUrl);
 
     userRepository.save(user);
-    return user.getEmail();
   }
 
   //가입한 이메일 찾기(아이디 찾기)


### PR DESCRIPTION
중복 닉네임 및 중복 휴대폰 번호  회원가입 / 회원정보 수정 불가능 하도록 처리 
(기존  email 중복 및 8글자 이하 비밀번호 불가에서 추가)

```
    if (userRepository.existsByEmail(userJoinDto.getEmail())) {
      throw new CustomException(ALREADY_EXIST_EMAIL);
    } else if (userJoinDto.getPassword() == null || userJoinDto.getPassword().length() < 8) {
      throw new CustomException(SHORT_PASSWORD);
    } else if (userRepository.existsByNickname(userJoinDto.getNickname())) {
      throw new CustomException(ALREADY_EXIST_NICKNAME);
    } else if (userRepository.existsByPhoneNumber(userJoinDto.getPhoneNumber())) {
      throw new CustomException(ALREADY_EXIST_PHONENUMBER);
    }
```
Service, Controller create, update, delete 등 각 도메인별 이름 수정 ex ) createNotice, updateShareBoard ...

mappedBy를 사용하여 user와 notice, shareBoard간의 중간테이블 생성되지 않도록 수정

유저의 닉네임과 휴대폰번호에 대해 유효성 검사를 진행하였지만, 
기존 닉네임과 휴대폰번호를 그대로 입력하게 된다면 exist 를 진행하는과정에서 오류가 발생하여 문제 해결 및 수정

password 검사는 dto에서 진행하고 있기 때문에 제외