### PR TITLE
젠킨스에서 gradlew 빌드 시 s3bucket의 경로를 찾지 못하는 이슈

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	implementation project(':s3bucket')
+
 }
 
 dependencyManagement{

--- a/s3bucket/build.gradle
+++ b/s3bucket/build.gradle
@@ -4,8 +4,17 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
-group = "com.zerobase.cms.order"
+group = "s3bucket"
 version = "0.0.1-SNAPSHOT"
+
+bootJar {
+    enabled = false
+}
+
+jar {
+    enabled = true
+}
+
 
 repositories {
     mavenCentral()

--- a/s3bucket/src/main/java/s3bucket/config/AmazonS3Config.java
+++ b/s3bucket/src/main/java/s3bucket/config/AmazonS3Config.java
@@ -1,4 +1,4 @@
-package kr.zb.nengtul.s3bucket.config;
+package s3bucket.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/s3bucket/src/main/java/s3bucket/service/AmazonS3Service.java
+++ b/s3bucket/src/main/java/s3bucket/service/AmazonS3Service.java
@@ -1,4 +1,4 @@
-package kr.zb.nengtul.s3bucket.service;
+package s3bucket.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;

--- a/src/main/java/kr/zb/nengtul/NengtulApplication.java
+++ b/src/main/java/kr/zb/nengtul/NengtulApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -13,6 +14,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableFeignClients //mailgun
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
+@ComponentScan({
+    "s3bucket", "kr.zb.nengtul"
+})
 public class NengtulApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
+++ b/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
@@ -9,7 +9,6 @@ import kr.zb.nengtul.recipe.domain.dto.RecipeGetListDto;
 import kr.zb.nengtul.recipe.domain.dto.RecipeUpdateDto;
 import kr.zb.nengtul.recipe.domain.entity.RecipeDocument;
 import kr.zb.nengtul.recipe.domain.repository.RecipeSearchRepository;
-import kr.zb.nengtul.s3bucket.service.AmazonS3Service;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +22,7 @@ import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+import s3bucket.service.AmazonS3Service;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
- root 폴더의 kr.zb의 경로가 같아 충돌로 인하여 못 찾는 것으로 예상. s3bucket의 경로에 kr.zb 삭제

- bean create 이슈 발생하여 ComponentScan으로 지정