### PR TITLE
fix : add password change

### DIFF
--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -10,6 +10,7 @@ import kr.zb.nengtul.user.domain.dto.UserFindEmailReqDto;
 import kr.zb.nengtul.user.domain.dto.UserFindEmailResDto;
 import kr.zb.nengtul.user.domain.dto.UserFindPasswordDto;
 import kr.zb.nengtul.user.domain.dto.UserJoinDto;
+import kr.zb.nengtul.user.domain.dto.UserPasswordChangeDto;
 import kr.zb.nengtul.user.domain.dto.UserUpdateDto;
 import kr.zb.nengtul.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -101,6 +102,13 @@ public class UserController {
   public ResponseEntity<Void> updateUser(Principal principal,
       @RequestBody @Valid UserUpdateDto userUpdateDto) {
     userService.updateUser(principal, userUpdateDto);
+    return ResponseEntity.ok(null);
+  }
+  @Operation(summary = "회원 비밀번호 변경", description = "토큰을 통해 회원을 인식하고, 회원에 대한 비밀번호를 수정합니다.")
+  @PutMapping("/detail/password")
+  public ResponseEntity<Void> changePassword(Principal principal,
+      @RequestBody @Valid UserPasswordChangeDto userPasswordChangeDto) {
+    userService.changePassword(principal, userPasswordChangeDto);
     return ResponseEntity.ok(null);
   }
 }

--- a/src/main/java/kr/zb/nengtul/user/domain/dto/UserDetailDto.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/dto/UserDetailDto.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 public class UserDetailDto {
   private String name;
   private String nickname;
-  private String password; //비밀번호 변경을 위해서
   private String phoneNumber;
   private String profileImageUrl;
   private ProviderType providerTYpe;
@@ -29,7 +28,6 @@ public class UserDetailDto {
     return UserDetailDto.builder()
         .name(user.getName())
         .nickname(user.getNickname())
-        .password(user.getPassword())
         .phoneNumber(user.getPhoneNumber())
         .profileImageUrl(user.getProfileImageUrl())
         .providerTYpe(user.getProviderType())

--- a/src/main/java/kr/zb/nengtul/user/domain/dto/UserPasswordChangeDto.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/dto/UserPasswordChangeDto.java
@@ -1,0 +1,23 @@
+package kr.zb.nengtul.user.domain.dto;
+
+import static kr.zb.nengtul.global.exception.ErrorCode.PASSWORD_NOT_NULL_MESSAGE;
+import static kr.zb.nengtul.global.exception.ErrorCode.SHORT_PASSWORD_LENGTH_MESSAGE;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPasswordChangeDto {
+  @NotEmpty(message = PASSWORD_NOT_NULL_MESSAGE)
+  @Size(min = 8, message = SHORT_PASSWORD_LENGTH_MESSAGE)
+  private String password;
+}

--- a/src/main/java/kr/zb/nengtul/user/domain/dto/UserUpdateDto.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/dto/UserUpdateDto.java
@@ -24,10 +24,6 @@ public class UserUpdateDto {
   @NotEmpty(message = NICKNAME_NOT_NULL_MESSAGE)
   private String nickname;
 
-  @NotEmpty(message = PASSWORD_NOT_NULL_MESSAGE)
-  @Size(min = 8, message = SHORT_PASSWORD_LENGTH_MESSAGE)
-  private String password;
-
   @NotEmpty(message = PHONE_NUMBER_NOT_NULL_MESSAGE)
   @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = PHONE_NUMBER_FORMAT_MESSAGE)
   private String phoneNumber;

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -7,15 +7,16 @@ import static kr.zb.nengtul.global.exception.ErrorCode.ALREADY_VERIFIED;
 import static kr.zb.nengtul.global.exception.ErrorCode.EXPIRED_CODE;
 import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_USER;
 import static kr.zb.nengtul.global.exception.ErrorCode.NO_CONTENT;
-import static kr.zb.nengtul.global.exception.ErrorCode.SHORT_PASSWORD;
 import static kr.zb.nengtul.global.exception.ErrorCode.WRONG_VERIFY_CODE;
 
 import java.security.Principal;
 import java.time.LocalDateTime;
 import kr.zb.nengtul.global.exception.CustomException;
+import kr.zb.nengtul.user.domain.dto.UserDetailDto;
 import kr.zb.nengtul.user.domain.dto.UserFindEmailReqDto;
 import kr.zb.nengtul.user.domain.dto.UserFindPasswordDto;
 import kr.zb.nengtul.user.domain.dto.UserJoinDto;
+import kr.zb.nengtul.user.domain.dto.UserPasswordChangeDto;
 import kr.zb.nengtul.user.domain.dto.UserUpdateDto;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.domain.repository.UserRepository;
@@ -24,6 +25,7 @@ import kr.zb.nengtul.user.mailgun.client.mailgun.SendMailForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.elasticsearch.client.security.ChangePasswordRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,7 +109,6 @@ public class UserService {
         userUpdateDto.getProfileImageUrl() == null ? "" : userUpdateDto.getProfileImageUrl();
 
     user.setNickname(userUpdateDto.getNickname());
-    user.setPassword(passwordEncoder.encode(userUpdateDto.getPassword()));
     user.setPhoneNumber(userUpdateDto.getPhoneNumber());
     user.setAddress(userUpdateDto.getAddress());
     user.setAddressDetail(userUpdateDto.getAddressDetail());
@@ -205,4 +206,13 @@ public class UserService {
     return userRepository.findByEmail(email)
         .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
   }
+
+  @Transactional
+  public void changePassword(Principal principal, UserPasswordChangeDto userPasswordChangeDto){
+    User user = findUserByEmail(principal.getName());
+
+    user.setPassword(passwordEncoder.encode(userPasswordChangeDto.getPassword()));
+    userRepository.save(user);
+  }
+
 }


### PR DESCRIPTION
비밀번호 변경 메소드 따로 구현

회원 상세보기시 비밀번호 제공X
회원 정보 수정시 비밀번호 변경X

사유 : 회원 상세보기시 암호화된 비밀번호가 주어지는데, 주어진 비밀번호를 복호화 할 수 없어 principle로 회원정보를 확인한 뒤 사용자의 정보를 토대로 비밀번호를 변경하여 set하도록 수정하였습니다.