### PR TITLE
Feature/comment, add profileImg

### DIFF
--- a/src/main/java/kr/zb/nengtul/comment/controller/CommentController.java
+++ b/src/main/java/kr/zb/nengtul/comment/controller/CommentController.java
@@ -1,0 +1,33 @@
+package kr.zb.nengtul.comment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
+import kr.zb.nengtul.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "COMMENT API", description = "댓글 API")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/v1/recipe/{recipeId}")
+public class CommentController {
+  private final CommentService commentService;
+  @Operation(summary = "댓글 작성", description = "토큰을 통해 회원 정보를 얻은 후 게시물에 대한 댓글을 작성합니다.")
+  @PostMapping
+  public ResponseEntity<Void> createComment(@PathVariable Long recipeId,
+      @RequestBody @Valid CommentReqDto commentReqDto,
+      Principal principal) {
+    commentService.createComment(recipeId, commentReqDto, principal);
+    return ResponseEntity.ok(null);
+  }
+}

--- a/src/main/java/kr/zb/nengtul/comment/controller/CommentController.java
+++ b/src/main/java/kr/zb/nengtul/comment/controller/CommentController.java
@@ -4,13 +4,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
+import kr.zb.nengtul.comment.domain.dto.CommentGetDto;
 import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
 import kr.zb.nengtul.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,15 +25,38 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/v1/recipe/{recipeId}")
+@RequestMapping("/v1/recipe")
 public class CommentController {
+
   private final CommentService commentService;
+
   @Operation(summary = "댓글 작성", description = "토큰을 통해 회원 정보를 얻은 후 게시물에 대한 댓글을 작성합니다.")
-  @PostMapping
-  public ResponseEntity<Void> createComment(@PathVariable Long recipeId,
-      @RequestBody @Valid CommentReqDto commentReqDto,
-      Principal principal) {
+  @PostMapping("/comment/{recipeId}")
+  public ResponseEntity<Void> createComment(@PathVariable String recipeId,
+      @RequestBody @Valid CommentReqDto commentReqDto, Principal principal) {
     commentService.createComment(recipeId, commentReqDto, principal);
     return ResponseEntity.ok(null);
+  }
+
+  @Operation(summary = "댓글 수정", description = "토큰을 통해 회원 정보를 댓글의 작성자와 비교한 후 댓글을 수정합니다.")
+  @PutMapping("/comment/{commentId}")
+  public ResponseEntity<Void> updateComment(@PathVariable Long commentId,
+      @RequestBody @Valid CommentReqDto commentReqDto, Principal principal) {
+    commentService.updateComment(commentId, commentReqDto, principal);
+    return ResponseEntity.ok(null);
+  }
+
+  @Operation(summary = "댓글 삭제", description = "토큰을 통해 회원 정보를 댓글의 작성자와 비교한 후 댓글을 삭제합니다.")
+  @DeleteMapping("/comment/{commentId}")
+  public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, Principal principal) {
+    commentService.deleteComment(commentId, principal);
+    return ResponseEntity.ok(null);
+  }
+
+  @Operation(summary = "댓글 조회", description = "레시피ID 를 통해 레시피ID에 대한 전체 댓글을 호출합니다.")
+  @GetMapping("/commentlist/{recipeId}")
+  public ResponseEntity<Page<CommentGetDto>> getComment(@PathVariable String recipeId,
+      Pageable pageable) {
+    return ResponseEntity.ok(commentService.findAllCommentByRecipeId(recipeId, pageable));
   }
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentGetDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentGetDto.java
@@ -1,0 +1,37 @@
+package kr.zb.nengtul.comment.domain.dto;
+
+import java.time.LocalDateTime;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentGetDto {
+
+  private String recipeId;
+  private Long commentId;
+  private Long userId;
+  private String userNickname;
+  private String content;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static CommentGetDto buildCommentGetDto(Comment comment) {
+    return CommentGetDto.builder()
+        .recipeId(comment.getRecipeId())
+        .commentId(comment.getId())
+        .userId(comment.getUser().getId())
+        .userNickname(comment.getUser().getNickname())
+        .content(comment.getContent())
+        .createdAt(comment.getCreatedAt())
+        .modifiedAt(comment.getModifiedAt())
+        .build();
+  }
+}

--- a/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentReqDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentReqDto.java
@@ -1,0 +1,21 @@
+package kr.zb.nengtul.comment.domain.dto;
+
+import static kr.zb.nengtul.global.exception.ErrorCode.CONTENT_NOT_NULL_MESSAGE;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentReqDto {
+  @NotEmpty(message = CONTENT_NOT_NULL_MESSAGE)
+  private String content;
+}

--- a/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentReqDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentReqDto.java
@@ -3,7 +3,6 @@ package kr.zb.nengtul.comment.domain.dto;
 import static kr.zb.nengtul.global.exception.ErrorCode.CONTENT_NOT_NULL_MESSAGE;
 
 import jakarta.validation.constraints.NotEmpty;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
@@ -23,11 +23,15 @@ public class Comment extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private Long recipeId;
+  private String recipeId;
 
   @JsonManagedReference
   @ManyToOne
   private User user;
 
   private String content;
+
+  public void setContent(String content) {
+    this.content = content;
+  }
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
@@ -1,0 +1,33 @@
+package kr.zb.nengtul.comment.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import kr.zb.nengtul.global.entity.BaseTimeEntity;
+import kr.zb.nengtul.user.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+public class Comment extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long recipeId;
+
+  @JsonManagedReference
+  @ManyToOne
+  private User user;
+
+  private String content;
+}

--- a/src/main/java/kr/zb/nengtul/comment/domain/respository/CommentRepository.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/respository/CommentRepository.java
@@ -1,0 +1,8 @@
+package kr.zb.nengtul.comment.domain.respository;
+
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/kr/zb/nengtul/comment/domain/respository/CommentRepository.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/respository/CommentRepository.java
@@ -1,8 +1,14 @@
 package kr.zb.nengtul.comment.domain.respository;
 
+import java.util.Optional;
 import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.user.domain.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+  Optional<Comment> findByIdAndUser(Long id, User user);
+  Page<Comment> findAllByRecipeId(String recipeId, Pageable pageable);
 }

--- a/src/main/java/kr/zb/nengtul/comment/service/CommentService.java
+++ b/src/main/java/kr/zb/nengtul/comment/service/CommentService.java
@@ -1,13 +1,22 @@
 package kr.zb.nengtul.comment.service;
 
+import static kr.zb.nengtul.global.exception.ErrorCode.NO_PERMISSION;
+
 import java.security.Principal;
+import kr.zb.nengtul.comment.domain.dto.CommentGetDto;
 import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
 import kr.zb.nengtul.comment.domain.entity.Comment;
 import kr.zb.nengtul.comment.domain.respository.CommentRepository;
+import kr.zb.nengtul.global.exception.CustomException;
+import kr.zb.nengtul.global.exception.ErrorCode;
+import kr.zb.nengtul.recipe.domain.entity.RecipeDocument;
+import kr.zb.nengtul.recipe.domain.repository.RecipeSearchRepository;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,17 +24,42 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class CommentService {
+
+  private final RecipeSearchRepository recipeSearchRepository;
   private final CommentRepository commentRepository;
   private final UserService userService;
 
   @Transactional
-  public void createComment(Long recipeId, CommentReqDto commentReqDto, Principal principal) {
+  public void createComment(String recipeId, CommentReqDto commentReqDto, Principal principal) {
     User user = userService.findUserByEmail(principal.getName());
+    RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
     Comment comment = Comment.builder()
-        .recipeId(recipeId)
+        .recipeId(recipeDocument.getId())
         .user(user)
         .content(commentReqDto.getContent())
         .build();
     commentRepository.save(comment);
+  }
+
+  @Transactional
+  public void updateComment(Long commentId, CommentReqDto commentReqDto, Principal principal) {
+    User user = userService.findUserByEmail(principal.getName());
+    Comment comment = commentRepository.findByIdAndUser(commentId, user)
+        .orElseThrow(() -> new CustomException(NO_PERMISSION));
+    comment.setContent(commentReqDto.getContent());
+    commentRepository.save(comment);
+  }
+  @Transactional
+  public void deleteComment(Long commentId, Principal principal) {
+    User user = userService.findUserByEmail(principal.getName());
+    Comment comment = commentRepository.findByIdAndUser(commentId, user)
+        .orElseThrow(() -> new CustomException(NO_PERMISSION));
+    commentRepository.delete(comment);
+  }
+
+  public Page<CommentGetDto> findAllCommentByRecipeId(String recipeId, Pageable pageable){
+    Page<Comment> commentList = commentRepository.findAllByRecipeId(recipeId, pageable);
+    return commentList.map(CommentGetDto::buildCommentGetDto);
   }
 }

--- a/src/main/java/kr/zb/nengtul/comment/service/CommentService.java
+++ b/src/main/java/kr/zb/nengtul/comment/service/CommentService.java
@@ -1,0 +1,31 @@
+package kr.zb.nengtul.comment.service;
+
+import java.security.Principal;
+import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.comment.domain.respository.CommentRepository;
+import kr.zb.nengtul.user.domain.entity.User;
+import kr.zb.nengtul.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+  private final CommentRepository commentRepository;
+  private final UserService userService;
+
+  @Transactional
+  public void createComment(Long recipeId, CommentReqDto commentReqDto, Principal principal) {
+    User user = userService.findUserByEmail(principal.getName());
+    Comment comment = Comment.builder()
+        .recipeId(recipeId)
+        .user(user)
+        .content(commentReqDto.getContent())
+        .build();
+    commentRepository.save(comment);
+  }
+}

--- a/src/main/java/kr/zb/nengtul/comment/service/CommentService.java
+++ b/src/main/java/kr/zb/nengtul/comment/service/CommentService.java
@@ -59,7 +59,9 @@ public class CommentService {
   }
 
   public Page<CommentGetDto> findAllCommentByRecipeId(String recipeId, Pageable pageable){
-    Page<Comment> commentList = commentRepository.findAllByRecipeId(recipeId, pageable);
+    RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
+    Page<Comment> commentList = commentRepository.findAllByRecipeId(recipeDocument.getId(), pageable);
     return commentList.map(CommentGetDto::buildCommentGetDto);
   }
 }

--- a/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
+++ b/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
@@ -69,11 +69,13 @@ public class SecurityConfig {
                 "/v1/user/findpw",//비밀번호 찾기 (비밀번호 재발급)
                 "/v1/user/findid",//아이디 찾기
                 "/v1/user/verify/**", //이메일 인증
-                "/v1/notice/list/**" //공지사항 조회관련
+                "/v1/notice/list/**", //공지사항 조회관련
+                "/v1/recipe/commentlist/**" //댓글 조회
             ).permitAll()
             .requestMatchers("/v1/user/**",
                 "/v1/shareboard/**",
-                "/v1/recipe/**"
+                "/v1/recipe/**",
+                "/v1/recipe/comment/**"//댓글 작성,수정,삭제
             ).hasAnyRole("USER", "ADMIN")
             .requestMatchers(
                 "/v1/admin/**",

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -24,7 +24,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "USER API", description = "회원 관련 API")
 @RestController
@@ -98,10 +100,11 @@ public class UserController {
 
   //회원 정보 수정(상세보기 페이지에서 진행)
   @Operation(summary = "회원 정보 수정", description = "토큰을 통해 회원을 인식하고, 회원에 대한 정보를 수정합니다.")
-  @PutMapping("/detail")
+  @PostMapping("/detail")
   public ResponseEntity<Void> updateUser(Principal principal,
-      @RequestBody @Valid UserUpdateDto userUpdateDto) {
-    userService.updateUser(principal, userUpdateDto);
+      @RequestPart(value = "userUpdateDto")  @Valid UserUpdateDto userUpdateDto,
+      @RequestPart(value = "image", required = false) MultipartFile image) {
+    userService.updateUser(principal, userUpdateDto, image);
     return ResponseEntity.ok(null);
   }
   @Operation(summary = "회원 비밀번호 변경", description = "토큰을 통해 회원을 인식하고, 회원에 대한 비밀번호를 수정합니다.")

--- a/src/main/java/kr/zb/nengtul/user/domain/dto/UserDetailDto.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/dto/UserDetailDto.java
@@ -14,6 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserDetailDto {
+  private Long id;
   private String name;
   private String nickname;
   private String phoneNumber;
@@ -26,6 +27,7 @@ public class UserDetailDto {
 
   public static UserDetailDto buildUserDetailDto(User user){
     return UserDetailDto.builder()
+        .id(user.getId())
         .name(user.getName())
         .nickname(user.getNickname())
         .phoneNumber(user.getPhoneNumber())

--- a/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.zb.nengtul.comment.domain.entity.Comment;
 import kr.zb.nengtul.global.entity.BaseTimeEntity;
 import kr.zb.nengtul.global.entity.ProviderType;
 import kr.zb.nengtul.global.entity.RoleType;
@@ -74,6 +75,10 @@ public class User extends BaseTimeEntity {
   @JsonBackReference
   @OneToMany(mappedBy = "user")
   private List<ShareBoard> shareBoardList;
+
+  @JsonBackReference
+  @OneToMany(mappedBy = "user")
+  private List<Comment> commentList;
 
   @Builder
   public User(String name, String nickname, String password, String phoneNumber,

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -106,15 +106,15 @@ public class UserService {
         && userRepository.existsByPhoneNumber(userUpdateDto.getPhoneNumber())) {
       throw new CustomException(ALREADY_EXIST_PHONENUMBER);
     }
-
-//    String updateProfileImageUrl = );
+    String profileImgUrl = (image != null)
+        ? amazonS3Service.uploadFileForProfile(image, principal.getName())
+        : user.getProfileImageUrl();
 
     user.setNickname(userUpdateDto.getNickname());
     user.setPhoneNumber(userUpdateDto.getPhoneNumber());
     user.setAddress(userUpdateDto.getAddress());
     user.setAddressDetail(userUpdateDto.getAddressDetail());
-    user.setProfileImageUrl(amazonS3Service.uploadFileForProfile(
-        image, principal.getName()));
+    user.setProfileImageUrl(profileImgUrl);
 
     userRepository.save(user);
   }


### PR DESCRIPTION
댓글 로직 구현

댓글 작성시 레시피 ID를 통해 특정 레시피에 댓글 작성하도록 구현.
작성 dto는 comment만 존재
```
   User user = userService.findUserByEmail(principal.getName());
    RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
```

댓글 수정/삭제시 댓글이 갖고있는 user 객체와 principle을 통해 조회한 user객체 를 비교한 뒤 동작
```
    User user = userService.findUserByEmail(principal.getName());
    Comment comment = commentRepository.findByIdAndUser(commentId, user)
        .orElseThrow(() -> new CustomException(NO_PERMISSION));
```
댓글 조회시 return dto
```
  private String recipeId;
  private Long commentId;
  private Long userId;
  private String userNickname;
  private String content;
  private LocalDateTime createdAt;
  private LocalDateTime modifiedAt;
```
제공, pageable사용

레시피에 대한 댓글이기 때문에 
                "/v1/recipe/commentlist/**" //댓글 조회 -> 전체 권한 가능
                "/v1/recipe/comment/**"//댓글 작성,수정,삭제 -> user,admin 권한 가능

프로필 사진 추가

RequestPart 형태로 json 형식의 dto를 받고
RequestPart 형태로 mulitpartfile 형태의 사진을 받아 회원정보 저장 
@RequestBody -> @RequestPart

```
  @Operation(summary = "회원 정보 수정", description = "토큰을 통해 회원을 인식하고, 회원에 대한 정보를 수정합니다.")
  @PostMapping("/detail")
  public ResponseEntity<Void> updateUser(Principal principal,
      @RequestPart(value = "userUpdateDto")  @Valid UserUpdateDto userUpdateDto,
      @RequestPart(value = "image", required = false) MultipartFile image) {
    userService.updateUser(principal, userUpdateDto, image);
    return ResponseEntity.ok(null);
  }
```

Notice, ShareBoard 사진 버킷 설정 생성시 추가 예정

UserDetail 유저 상세보기 조회시에 userId 같이 출력되도록 dto수정