### PR TITLE
Feature/elasticsearch document update

### DIFF
--- a/s3bucket/src/main/java/s3bucket/service/AmazonS3Service.java
+++ b/s3bucket/src/main/java/s3bucket/service/AmazonS3Service.java
@@ -47,10 +47,10 @@ public class AmazonS3Service {
     }
 
     public String uploadFileForRecipeCookingStep(
-            List<MultipartFile> files, String recipeId) {
+            List<MultipartFile> files, String uuidRandom) {
 
         try {
-            log.info("[uploadFileForRecipeCookingStep 시작]" + " RecipeId : " + recipeId);
+            log.info("[uploadFileForRecipeCookingStep 시작]" + " UUID : " + uuidRandom);
 
             ObjectMetadata metadata = new ObjectMetadata();
 
@@ -58,10 +58,11 @@ public class AmazonS3Service {
 
             int count = 1;
             for (MultipartFile file : files) {
+
                 metadata.setContentType(file.getContentType());
                 metadata.setContentLength(file.getSize());
 
-                String fileKey = "RecipeCookingStep/" + recipeId + "/" + count++;
+                String fileKey = "RecipeCookingStep/" + uuidRandom + "/" + count++;
 
                 amazonS3Client.putObject(bucket, fileKey, file.getInputStream(), metadata);
 
@@ -69,8 +70,34 @@ public class AmazonS3Service {
                         .append("\\");
             }
 
-            log.info("[uploadFileForRecipeCookingStep 완료]" + " RecipeId : " + recipeId);
+            log.info("[uploadFileForRecipeCookingStep 완료]" + " UUID : " + uuidRandom);
             return stringBuilder.toString();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.info(e.getMessage());
+        }
+
+        return "";
+    }
+
+    public String uploadFileForRecipeThumbnail(
+            MultipartFile file, String stringUUID) {
+
+        try {
+            log.info("[uploadFileForRecipeThumbnail 시작]" + " UUID : " + stringUUID);
+
+            ObjectMetadata metadata = new ObjectMetadata();
+
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getSize());
+
+            String fileKey = "thumbnail/" + stringUUID;
+
+            amazonS3Client.putObject(bucket, fileKey, file.getInputStream(), metadata);
+
+            log.info("[uploadFileForRecipeThumbnail 완료]" + " UUID : " + stringUUID);
+            return amazonS3Client.getUrl(bucket, fileKey).toString();
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/kr/zb/nengtul/recipe/config/ElasticSearchConfig.java
+++ b/src/main/java/kr/zb/nengtul/recipe/config/ElasticSearchConfig.java
@@ -15,11 +15,20 @@ public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
     @Value("${spring.elasticsearch.uris}")
     private String elasticSearchHostUri;
 
+    @Value("${spring.elasticsearch.username}")
+    private String userName;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+
     @Override
     public RestHighLevelClient elasticsearchClient() {
 
         ClientConfiguration configuration = ClientConfiguration.builder()
-                .connectedTo(elasticSearchHostUri).build();
+                .connectedTo(elasticSearchHostUri)
+                .withBasicAuth(userName, password)
+                .build();
 
         return RestClients.create(configuration).rest();
     }

--- a/src/main/java/kr/zb/nengtul/recipe/controller/RecipeController.java
+++ b/src/main/java/kr/zb/nengtul/recipe/controller/RecipeController.java
@@ -28,9 +28,10 @@ public class RecipeController {
     @PostMapping
     ResponseEntity<?> addRecipe(Principal principal,
                                 @RequestPart @Valid RecipeAddDto recipeAddDto,
-                                @RequestPart List<MultipartFile> images) {
+                                @RequestPart List<MultipartFile> images,
+                                @RequestPart MultipartFile thumbnail) {
 
-        recipeService.addRecipe(principal, recipeAddDto, images);
+        recipeService.addRecipe(principal, recipeAddDto, images, thumbnail);
 
         return ResponseEntity.ok(null);
     }
@@ -77,9 +78,14 @@ public class RecipeController {
     @PutMapping("/{recipeId}")
     ResponseEntity<?> updateRecipe(Principal principal,
                                    @PathVariable String recipeId,
-                                   @RequestBody RecipeUpdateDto recipeUpdateDto) {
+                                   @RequestPart RecipeUpdateDto recipeUpdateDto,
+                                   @RequestPart List<MultipartFile> images,
+                                   @RequestPart MultipartFile thumbnail) {
 
-        recipeService.updateRecipe(principal, recipeId, recipeUpdateDto);
+        //바꿀 url, update 사진  ->  처리
+
+        recipeService.updateRecipe(principal, recipeId, recipeUpdateDto,
+                images, thumbnail);
 
         return ResponseEntity.ok(null);
     }

--- a/src/main/java/kr/zb/nengtul/recipe/controller/RecipeController.java
+++ b/src/main/java/kr/zb/nengtul/recipe/controller/RecipeController.java
@@ -82,8 +82,6 @@ public class RecipeController {
                                    @RequestPart List<MultipartFile> images,
                                    @RequestPart MultipartFile thumbnail) {
 
-        //바꿀 url, update 사진  ->  처리
-
         recipeService.updateRecipe(principal, recipeId, recipeUpdateDto,
                 images, thumbnail);
 

--- a/src/main/java/kr/zb/nengtul/recipe/domain/constants/RecipeCategory.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/constants/RecipeCategory.java
@@ -20,7 +20,8 @@ public enum RecipeCategory {
     BREAD("빵"),
     SNACKS("과자"),
     TEA_DRINK("차/음료/술"),
-    ETC("기타")
+    ETC("기타"),
+    NONE("없음")
     ;
 
     final String korean;

--- a/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeGetDetailDto.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeGetDetailDto.java
@@ -26,6 +26,8 @@ public class RecipeGetDetailDto {
 
     private String cookingStep;
 
+    private String thumbnailUrl;
+
     private String imageUrl;
 
     private String cookingTime;
@@ -59,6 +61,7 @@ public class RecipeGetDetailDto {
                 .createdAt(recipeDocument.getCreatedAt())
                 .modifiedAt(recipeDocument.getModifiedAt())
                 .viewCount(recipeDocument.getViewCount())
+                .thumbnailUrl(recipeDocument.getThumbnailUrl())
                 .build();
 
     }

--- a/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeGetListDto.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeGetListDto.java
@@ -19,12 +19,15 @@ public class RecipeGetListDto {
 
     private Long likeCount;
 
+    private String thumbnailUrl;
+
     public static RecipeGetListDto fromRecipeDocument(RecipeDocument recipeDocument) {
 
         return RecipeGetListDto.builder()
                 .recipeId(recipeDocument.getId())
                 .title(recipeDocument.getTitle())
                 .viewCount(recipeDocument.getViewCount())
+                .thumbnailUrl(recipeDocument.getThumbnailUrl())
                 .build();
 
     }

--- a/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeUpdateDto.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeUpdateDto.java
@@ -18,9 +18,9 @@ public class RecipeUpdateDto {
 
     private String ingredient;
 
-    private String cookingStep;
+    private String imagesUrl;
 
-    private String imageUrl;
+    private String cookingStep;
 
     private String cookingTime;
 

--- a/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
@@ -72,39 +72,35 @@ public class RecipeDocument {
 
     public void updateRecipe(RecipeUpdateDto recipeUpdateDto) {
 
-        if (recipeUpdateDto.getTitle() != null) {
+        if (!recipeUpdateDto.getTitle().isEmpty()) {
             this.title = recipeUpdateDto.getTitle();
         }
 
-        if (recipeUpdateDto.getIntro() != null) {
+        if (!recipeUpdateDto.getIntro().isEmpty()) {
             this.ingredient = recipeUpdateDto.getIntro();
         }
 
-        if (recipeUpdateDto.getIngredient() != null) {
+        if (!recipeUpdateDto.getIngredient().isEmpty()) {
             this.ingredient = recipeUpdateDto.getIngredient();
         }
 
-        if (recipeUpdateDto.getCookingStep() != null) {
+        if (!recipeUpdateDto.getCookingStep().isEmpty()) {
             this.cookingStep = recipeUpdateDto.getCookingStep();
         }
 
-        if (recipeUpdateDto.getImageUrl() != null) {
-            this.imageUrl = recipeUpdateDto.getImageUrl();
-        }
-
-        if (recipeUpdateDto.getCookingTime() != null) {
+        if (!recipeUpdateDto.getCookingTime().isEmpty()) {
             this.cookingTime = recipeUpdateDto.getCookingTime();
         }
 
-        if (recipeUpdateDto.getServing() != null) {
+        if (!recipeUpdateDto.getServing().isEmpty()) {
             this.serving = recipeUpdateDto.getServing();
         }
 
-        if (recipeUpdateDto.getRecipeCategory() != null) {
+        if (!recipeUpdateDto.getRecipeCategory().equals(RecipeCategory.None)) {
             this.category = recipeUpdateDto.getRecipeCategory();
         }
 
-        if (recipeUpdateDto.getVideoUrl() != null) {
+        if (!recipeUpdateDto.getVideoUrl().isEmpty()) {
             this.videoUrl = recipeUpdateDto.getVideoUrl();
         }
 

--- a/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
@@ -44,7 +44,7 @@ public class RecipeDocument {
     private String cookingStep;
 
     @Field(type = FieldType.Keyword, index = false)
-    private String thumbnail;
+    private String thumbnailUrl;
 
     @Field(type = FieldType.Keyword, index = false)
     private String imageUrl;

--- a/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
@@ -44,6 +44,9 @@ public class RecipeDocument {
     private String cookingStep;
 
     @Field(type = FieldType.Keyword, index = false)
+    private String thumbnail;
+
+    @Field(type = FieldType.Keyword, index = false)
     private String imageUrl;
 
     @Field(type = FieldType.Keyword)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,11 +8,11 @@ spring:
     hikari:
       pool-name: jpa-hikari-pool
       maximum-pool-size: 5
-  # JPA ??
   elasticsearch:
     uris: ${ES_URI}
-#    password: ${ES_PASSWORD}
-#    username: ${ES_USER_NAME}
+    password: ${ES_PASSWORD}
+    username: ${ES_USER_NAME}
+  # JPA ??
   jpa:
     generate-ddl: true
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/elasticsearch/recipe-mappings.json
+++ b/src/main/resources/elasticsearch/recipe-mappings.json
@@ -26,6 +26,18 @@
       "type": "keyword"
     },
 
+    "thumbnailUrl": {
+      "type": "keyword"
+    },
+
+    "imageUrl": {
+      "type": "keyword"
+    },
+
+    "cookingTime": {
+      "type": "keyword"
+    },
+
     "serving": {
       "type": "keyword"
     },

--- a/src/test/java/kr/zb/nengtul/recipe/service/RecipeServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/recipe/service/RecipeServiceTest.java
@@ -21,10 +21,7 @@ import s3bucket.service.AmazonS3Service;
 
 import java.security.Principal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -141,6 +138,7 @@ class RecipeServiceTest {
         //given
         RecipeAddDto recipeAddDto = new RecipeAddDto();
         List<MultipartFile> images = Collections.singletonList(mock(MultipartFile.class));
+        MultipartFile thumbnail = mock(MultipartFile.class);
 
         User user = new User();
 
@@ -150,7 +148,7 @@ class RecipeServiceTest {
                 .thenReturn("image_url");
 
         //when
-        recipeService.addRecipe(mock(Principal.class), recipeAddDto, images);
+        recipeService.addRecipe(mock(Principal.class), recipeAddDto, images, thumbnail);
 
         //then
         verify(recipeSearchRepository, times(1))
@@ -282,6 +280,9 @@ class RecipeServiceTest {
                 .title("수정된 타이틀")
                 .ingredient("수정된 재료")
                 .recipeCategory(RecipeCategory.ETC)
+                .imagesUrl("수정된 Url")
+                .intro("")
+                .videoUrl("")
                 .cookingStep("수정된 조리 스텝")
                 .cookingTime("수정된 시간")
                 .serving("수정된 양")
@@ -300,6 +301,7 @@ class RecipeServiceTest {
                 .ingredient("재료1, 재료2, 재료3")
                 .cookingStep("테스트 쿠킹 스텝")
                 .imageUrl("testimageurl1")
+                .thumbnailUrl("testThumbnailUrl")
                 .cookingTime("30분")
                 .serving("1인분")
                 .viewCount(0L)
@@ -317,9 +319,9 @@ class RecipeServiceTest {
         when(recipeSearchRepository.findById(any()))
                 .thenReturn(Optional.of(recipeDocument));
 
-
         //when
-        recipeService.updateRecipe(principal, recipeDocument.getId(), recipeUpdateDto);
+        recipeService.updateRecipe(principal, recipeDocument.getId(), recipeUpdateDto,
+                Collections.singletonList(mock(MultipartFile.class)), mock(MultipartFile.class));
 
         //then
         assertEquals(recipeDocument.getTitle(), recipeUpdateDto.getTitle());
@@ -367,6 +369,5 @@ class RecipeServiceTest {
         verify(recipeSearchRepository, times(1))
                 .delete(any(RecipeDocument.class));
     }
-
 
 }


### PR DESCRIPTION
RecipeDocument
---
- thumbnail 인덱스 추가
- mapping 문서에 thumbnail, imageUrl 추가

Elasticsearch 
---
- BasicSecurity 적용하여 사용 시 user, password
 필요하도록 설정
- 레시피 생성 시 S3에 저장 후 리턴되는 Url이 한글이 들어가면 깨지기 때문에 원래 들어가던 인자인 Title 지우고 UUID로 랜덤 값 생성 후 넣는 것으로 변경
- 레시피 수정 시 값을 넣지 않으면 null -> ""로 변경되어 해당 로직 수정, Category는 Enum 값이기 때문에 ""로 입력 시 오류 발생. Enum 값 NONE 만들어서 ""일 때는 NONE으로 요청하도록 프론트엔드에 요청 예정