### PR TITLE
Feature/replycomment

### DIFF
--- a/src/main/java/kr/zb/nengtul/comment/controller/CommentController.java
+++ b/src/main/java/kr/zb/nengtul/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.security.Principal;
+import java.util.List;
 import kr.zb.nengtul.comment.domain.dto.CommentGetDto;
 import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
 import kr.zb.nengtul.comment.service.CommentService;
@@ -25,13 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/v1/recipe")
+@RequestMapping("/v1/recipes")
 public class CommentController {
 
   private final CommentService commentService;
 
   @Operation(summary = "댓글 작성", description = "토큰을 통해 회원 정보를 얻은 후 게시물에 대한 댓글을 작성합니다.")
-  @PostMapping("/comment/{recipeId}")
+  @PostMapping("/{recipeId}/comments")
   public ResponseEntity<Void> createComment(@PathVariable String recipeId,
       @RequestBody @Valid CommentReqDto commentReqDto, Principal principal) {
     commentService.createComment(recipeId, commentReqDto, principal);
@@ -39,7 +40,7 @@ public class CommentController {
   }
 
   @Operation(summary = "댓글 수정", description = "토큰을 통해 회원 정보를 댓글의 작성자와 비교한 후 댓글을 수정합니다.")
-  @PutMapping("/comment/{commentId}")
+  @PutMapping("/comments/{commentId}")
   public ResponseEntity<Void> updateComment(@PathVariable Long commentId,
       @RequestBody @Valid CommentReqDto commentReqDto, Principal principal) {
     commentService.updateComment(commentId, commentReqDto, principal);
@@ -47,16 +48,15 @@ public class CommentController {
   }
 
   @Operation(summary = "댓글 삭제", description = "토큰을 통해 회원 정보를 댓글의 작성자와 비교한 후 댓글을 삭제합니다.")
-  @DeleteMapping("/comment/{commentId}")
+  @DeleteMapping("/comments/{commentId}")
   public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, Principal principal) {
     commentService.deleteComment(commentId, principal);
     return ResponseEntity.ok(null);
   }
 
   @Operation(summary = "댓글 조회", description = "레시피ID 를 통해 레시피ID에 대한 전체 댓글을 호출합니다.")
-  @GetMapping("/commentlist/{recipeId}")
-  public ResponseEntity<Page<CommentGetDto>> getComment(@PathVariable String recipeId,
-      Pageable pageable) {
-    return ResponseEntity.ok(commentService.findAllCommentByRecipeId(recipeId, pageable));
+  @GetMapping("/{recipeId}/commentlist")
+  public ResponseEntity<List<CommentGetDto>> getComment(@PathVariable String recipeId) {
+    return ResponseEntity.ok(commentService.findAllCommentByRecipeId(recipeId));
   }
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentGetDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentGetDto.java
@@ -1,7 +1,9 @@
 package kr.zb.nengtul.comment.domain.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.comment.replycomment.domain.dto.ReplyCommentGetDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,19 +21,8 @@ public class CommentGetDto {
   private Long commentId;
   private Long userId;
   private String userNickname;
-  private String content;
+  private String comment;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;
-
-  public static CommentGetDto buildCommentGetDto(Comment comment) {
-    return CommentGetDto.builder()
-        .recipeId(comment.getRecipeId())
-        .commentId(comment.getId())
-        .userId(comment.getUser().getId())
-        .userNickname(comment.getUser().getNickname())
-        .content(comment.getContent())
-        .createdAt(comment.getCreatedAt())
-        .modifiedAt(comment.getModifiedAt())
-        .build();
-  }
+  private List<ReplyCommentGetDto> replyCommentGetDtoList;
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentReqDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/dto/CommentReqDto.java
@@ -16,5 +16,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CommentReqDto {
   @NotEmpty(message = CONTENT_NOT_NULL_MESSAGE)
-  private String content;
+  private String comment;
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
@@ -43,4 +43,8 @@ public class Comment extends BaseTimeEntity {
   public void setComment(String comment) {
     this.comment = comment;
   }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/entity/Comment.java
@@ -1,11 +1,16 @@
 package kr.zb.nengtul.comment.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import kr.zb.nengtul.comment.replycomment.domain.entity.ReplyComment;
 import kr.zb.nengtul.global.entity.BaseTimeEntity;
 import kr.zb.nengtul.user.domain.entity.User;
 import lombok.AllArgsConstructor;
@@ -29,9 +34,13 @@ public class Comment extends BaseTimeEntity {
   @ManyToOne
   private User user;
 
-  private String content;
+  private String comment;
 
-  public void setContent(String content) {
-    this.content = content;
+  @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+  @JsonBackReference
+  private List<ReplyComment> replyCommentList;
+
+  public void setComment(String comment) {
+    this.comment = comment;
   }
 }

--- a/src/main/java/kr/zb/nengtul/comment/domain/respository/CommentRepository.java
+++ b/src/main/java/kr/zb/nengtul/comment/domain/respository/CommentRepository.java
@@ -1,5 +1,6 @@
 package kr.zb.nengtul.comment.domain.respository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.zb.nengtul.comment.domain.entity.Comment;
 import kr.zb.nengtul.user.domain.entity.User;
@@ -10,5 +11,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   Optional<Comment> findByIdAndUser(Long id, User user);
-  Page<Comment> findAllByRecipeId(String recipeId, Pageable pageable);
+  List<Comment> findAllByRecipeId(String recipeId);
 }

--- a/src/main/java/kr/zb/nengtul/comment/replycomment/controller/ReplyCommentController.java
+++ b/src/main/java/kr/zb/nengtul/comment/replycomment/controller/ReplyCommentController.java
@@ -1,0 +1,54 @@
+package kr.zb.nengtul.comment.replycomment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import kr.zb.nengtul.comment.replycomment.domain.dto.ReplyCommentReqDto;
+import kr.zb.nengtul.comment.replycomment.service.ReplyCommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "REPLY COMMENT API", description = "대댓글 API")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/v1/comments/{commentId}")
+public class ReplyCommentController {
+
+  private final ReplyCommentService replyCommentService;
+
+  @Operation(summary = "대댓글 작성", description = "토큰을 통해 회원 정보를 얻은 후 댓글에 대한 대댓글을 작성합니다.")
+  @PostMapping
+  public ResponseEntity<Void> createReplyComment(@PathVariable Long commentId,
+      @RequestBody @Valid ReplyCommentReqDto replyCommentReqDto, Principal principal) {
+    replyCommentService.createReplyComment(commentId, replyCommentReqDto, principal);
+    return ResponseEntity.ok(null);
+  }
+
+  @Operation(summary = "대댓글 수정", description = "토큰을 통해 회원 정보를 얻은 후 자신이 작성한 대댓글을 수정한다.")
+  @PutMapping("/replycommets/{replyCommentId}")
+  public ResponseEntity<Void> updateReplyComment(@PathVariable Long commentId,
+      @PathVariable Long replyCommentId, @RequestBody @Valid ReplyCommentReqDto replyCommentReqDto,
+      Principal principal) {
+    replyCommentService.updateReplyComment(commentId, replyCommentId, replyCommentReqDto,
+        principal);
+    return ResponseEntity.ok(null);
+  }
+
+  @Operation(summary = "대댓글 삭제", description = "토큰을 통해 회원 정보를 얻은 후 자신이 작성한 대댓글을 삭제한다.")
+  @DeleteMapping("/replycommets/{replyCommentId}")
+  public ResponseEntity<Void> deleteReplyComment(@PathVariable Long commentId,
+      @PathVariable Long replyCommentId, Principal principal) {
+    replyCommentService.deleteReplyComment(commentId, replyCommentId, principal);
+    return ResponseEntity.ok(null);
+  }
+}

--- a/src/main/java/kr/zb/nengtul/comment/replycomment/domain/dto/ReplyCommentGetDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/replycomment/domain/dto/ReplyCommentGetDto.java
@@ -1,0 +1,38 @@
+package kr.zb.nengtul.comment.replycomment.domain.dto;
+
+import java.time.LocalDateTime;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.comment.replycomment.domain.entity.ReplyComment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyCommentGetDto {
+
+  private Long replyCommentId;
+  private Long commentId;
+  private Long userId;
+  private String replyComment;
+  private String userNickname;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static ReplyCommentGetDto buildCommentGetDto(ReplyComment replyComment) {
+    return ReplyCommentGetDto.builder()
+        .replyCommentId(replyComment.getId())
+        .commentId(replyComment.getComment().getId())
+        .userId(replyComment.getUser().getId())
+        .replyComment(replyComment.getReplyComment())
+        .userNickname(replyComment.getUser().getNickname())
+        .createdAt(replyComment.getCreatedAt())
+        .modifiedAt(replyComment.getModifiedAt())
+        .build();
+  }
+}

--- a/src/main/java/kr/zb/nengtul/comment/replycomment/domain/dto/ReplyCommentReqDto.java
+++ b/src/main/java/kr/zb/nengtul/comment/replycomment/domain/dto/ReplyCommentReqDto.java
@@ -1,0 +1,20 @@
+package kr.zb.nengtul.comment.replycomment.domain.dto;
+
+import static kr.zb.nengtul.global.exception.ErrorCode.CONTENT_NOT_NULL_MESSAGE;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyCommentReqDto {
+  @NotEmpty(message = CONTENT_NOT_NULL_MESSAGE)
+  private String replyComment;
+}

--- a/src/main/java/kr/zb/nengtul/comment/replycomment/domain/entity/ReplyComment.java
+++ b/src/main/java/kr/zb/nengtul/comment/replycomment/domain/entity/ReplyComment.java
@@ -1,0 +1,41 @@
+package kr.zb.nengtul.comment.replycomment.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.global.entity.BaseTimeEntity;
+import kr.zb.nengtul.user.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+public class ReplyComment extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @JsonManagedReference
+  @ManyToOne
+  private User user;
+
+  @JsonManagedReference
+  @ManyToOne
+  private Comment comment;
+
+  private String replyComment;
+
+  public void setReplyComment(String replyComment) {
+    this.replyComment = replyComment;
+  }
+}

--- a/src/main/java/kr/zb/nengtul/comment/replycomment/domain/repository/ReplyCommentRepository.java
+++ b/src/main/java/kr/zb/nengtul/comment/replycomment/domain/repository/ReplyCommentRepository.java
@@ -1,0 +1,14 @@
+package kr.zb.nengtul.comment.replycomment.domain.repository;
+
+
+import java.util.List;
+import java.util.Optional;
+import kr.zb.nengtul.comment.replycomment.domain.entity.ReplyComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long> {
+
+  List<ReplyComment> findByCommentId(Long commentId);
+  Optional<ReplyComment> findByIdAndCommentId(Long id, Long commentId);
+
+}

--- a/src/main/java/kr/zb/nengtul/comment/replycomment/service/ReplyCommentService.java
+++ b/src/main/java/kr/zb/nengtul/comment/replycomment/service/ReplyCommentService.java
@@ -1,0 +1,80 @@
+package kr.zb.nengtul.comment.replycomment.service;
+
+import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_COMMENT;
+import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_REPLY_COMMENT;
+import static kr.zb.nengtul.global.exception.ErrorCode.NO_PERMISSION;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.comment.domain.respository.CommentRepository;
+import kr.zb.nengtul.comment.replycomment.domain.dto.ReplyCommentGetDto;
+import kr.zb.nengtul.comment.replycomment.domain.dto.ReplyCommentReqDto;
+import kr.zb.nengtul.comment.replycomment.domain.entity.ReplyComment;
+import kr.zb.nengtul.comment.replycomment.domain.repository.ReplyCommentRepository;
+import kr.zb.nengtul.global.exception.CustomException;
+import kr.zb.nengtul.global.exception.ErrorCode;
+import kr.zb.nengtul.user.domain.entity.User;
+import kr.zb.nengtul.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReplyCommentService {
+
+  private final CommentRepository commentRepository;
+
+  private final ReplyCommentRepository replyCommentRepository;
+  private final UserService userService;
+
+  @Transactional
+  public void createReplyComment(Long commentId, ReplyCommentReqDto replyCommentReqDto,
+      Principal principal) {
+    User user = userService.findUserByEmail(principal.getName());
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_COMMENT));
+    ReplyComment replyComment = ReplyComment.builder()
+        .replyComment(replyCommentReqDto.getReplyComment())
+        .user(user)
+        .comment(comment)
+        .build();
+
+    replyCommentRepository.save(replyComment);
+  }
+
+  @Transactional
+  public void updateReplyComment(Long commentId, Long replyCommentId,
+      ReplyCommentReqDto replyCommentReqDto, Principal principal) {
+    User user = userService.findUserByEmail(principal.getName());
+    ReplyComment replyComment = replyCommentRepository.findByIdAndCommentId(
+        replyCommentId, commentId).orElseThrow(() -> new CustomException(NOT_FOUND_REPLY_COMMENT));
+    if (!user.equals(replyComment.getUser())) {
+      throw new CustomException(NO_PERMISSION);
+    }
+    replyComment.setReplyComment(replyCommentReqDto.getReplyComment());
+    replyCommentRepository.save(replyComment);
+  }
+
+  @Transactional
+  public void deleteReplyComment(Long commentId, Long replyCommentId, Principal principal) {
+    User user = userService.findUserByEmail(principal.getName());
+    ReplyComment replyComment = replyCommentRepository.findByIdAndCommentId(
+        replyCommentId, commentId).orElseThrow(() -> new CustomException(NOT_FOUND_REPLY_COMMENT));
+    if (!user.equals(replyComment.getUser())) {
+      throw new CustomException(NO_PERMISSION);
+    }
+    replyCommentRepository.delete(replyComment);
+  }
+
+  public List<ReplyCommentGetDto> getReplyCommentByComment(Long commentId) {
+    List<ReplyComment> replyCommentList = replyCommentRepository.findByCommentId(commentId);
+    return replyCommentList.stream().map(ReplyCommentGetDto::buildCommentGetDto)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
+++ b/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
@@ -67,8 +67,10 @@ public class SecurityConfig {
         //== URL별 권한 관리 옵션 ==//
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(HttpMethod.GET, "/v1/recipe/**").permitAll()
+            .requestMatchers(HttpMethod.GET, "/v1/recipes/**").permitAll() //댓글
+            .requestMatchers(HttpMethod.GET, "/v1/comments/**").permitAll()//대댓글
             .requestMatchers(
-                "/","/**",
+                "/", "/**",
                 "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/v2/api-docs/**",
                 "/v1/auth/**",
                 "/v1/user/join",//회원가입
@@ -83,7 +85,8 @@ public class SecurityConfig {
                 "/v1/user/**",
                 "/v1/shareboard/**",
                 "/v1/recipe/**",
-                "/v1/recipe/comment/**",//댓글 작성,수정,삭제
+                "/v1/comments/**",//대댓글
+                "/v1/recipes/comment/**",//댓글 작성,수정,삭제
                 "/v1/likes/**",
                 "/v1/favorite/**"
             ).hasAnyRole("USER", "ADMIN")

--- a/src/main/java/kr/zb/nengtul/global/exception/ErrorCode.java
+++ b/src/main/java/kr/zb/nengtul/global/exception/ErrorCode.java
@@ -43,7 +43,12 @@ public enum ErrorCode {
   NOT_NULL_CONTENT(HttpStatus.BAD_REQUEST, "내용을 입력해 주세요."),
   NO_CONTENT(HttpStatus.NO_CONTENT, "일치하는 내용이 없습니다."),
   NO_PERMISSION(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-  NOT_VERIFY_EMAIL(HttpStatus.FORBIDDEN, "이메일 인증을 하지 않아 작성 권한이 없습니다.");
+  NOT_VERIFY_EMAIL(HttpStatus.FORBIDDEN, "이메일 인증을 하지 않아 작성 권한이 없습니다."),
+  //댓글
+  NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+
+  //대댓글
+  NOT_FOUND_REPLY_COMMENT(HttpStatus.NOT_FOUND, "대댓글을 찾을 수 없습니다.");
 
   //ExceptionHandler 에서 MethodArgumentNotValidException 용으로 사용
   //유저

--- a/src/main/java/kr/zb/nengtul/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/zb/nengtul/global/jwt/JwtTokenProvider.java
@@ -7,6 +7,8 @@ package kr.zb.nengtul.global.jwt;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -142,9 +144,13 @@ public class JwtTokenProvider {
     try {
       JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
       return true;
+    } catch (SignatureVerificationException e) {
+      log.error("Signature verification failed: {}", e.getMessage());
+    } catch (TokenExpiredException e) {
+      log.error("Token expired: {}", e.getMessage());
     } catch (Exception e) {
-      log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
-      return false;
+      log.error("Invalid token: {}", e.getMessage());
     }
+    return false;
   }
 }

--- a/src/test/java/kr/zb/nengtul/comment/replycomment/service/ReplyCommentServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/comment/replycomment/service/ReplyCommentServiceTest.java
@@ -1,0 +1,154 @@
+package kr.zb.nengtul.comment.replycomment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.util.Optional;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.comment.domain.respository.CommentRepository;
+import kr.zb.nengtul.comment.replycomment.domain.dto.ReplyCommentReqDto;
+import kr.zb.nengtul.comment.replycomment.domain.entity.ReplyComment;
+import kr.zb.nengtul.comment.replycomment.domain.repository.ReplyCommentRepository;
+import kr.zb.nengtul.comment.service.CommentService;
+import kr.zb.nengtul.recipe.domain.repository.RecipeSearchRepository;
+import kr.zb.nengtul.user.domain.entity.User;
+import kr.zb.nengtul.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ReplyCommentServiceTest {
+
+  private CommentRepository commentRepository;
+  private UserService userService;
+  private ReplyCommentService replyCommentService;
+  private ReplyCommentRepository replyCommentRepository;
+
+  @BeforeEach
+  void setUp() {
+    replyCommentRepository = mock(ReplyCommentRepository.class);
+    commentRepository = mock(CommentRepository.class);
+    userService = mock(UserService.class);
+
+    replyCommentService = new ReplyCommentService(
+        commentRepository, replyCommentRepository, userService);
+  }
+
+
+  @Test
+  @DisplayName("대댓글 작성 성공")
+  void createReplyComment_SUCCESS() {
+    // given
+    Long commentId = 1L;
+    String userEmail = "aa@aa.aa";
+    ReplyCommentReqDto replyCommentReqDto = new ReplyCommentReqDto();
+    replyCommentReqDto.setReplyComment("대댓글");
+
+    User user = User.builder()
+        .email(userEmail)
+        .build();
+    Comment comment = Comment.builder()
+        .id(commentId)
+        .build();
+
+    when(userService.findUserByEmail(userEmail)).thenReturn(user);
+    when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+    ReplyComment replyComment = ReplyComment.builder()
+        .replyComment(replyCommentReqDto.getReplyComment())
+        .user(user)
+        .comment(comment)
+        .build();
+
+    when(replyCommentRepository.save(any(ReplyComment.class))).thenReturn(replyComment);
+
+    // when
+    replyCommentService.createReplyComment(commentId, replyCommentReqDto, mockPrincipal(userEmail));
+
+    // then
+    ArgumentCaptor<ReplyComment> replyCommentCaptor = ArgumentCaptor.forClass(ReplyComment.class);
+    verify(replyCommentRepository).save(replyCommentCaptor.capture());
+
+    ReplyComment capturedReplyComment = replyCommentCaptor.getValue();
+    assertEquals(commentId, capturedReplyComment.getComment().getId());
+    assertEquals(user, capturedReplyComment.getUser());
+    assertEquals(replyCommentReqDto.getReplyComment(), capturedReplyComment.getReplyComment());
+  }
+
+
+  @Test
+  @DisplayName("대댓글 수정 성공")
+  void updateReplyComment_SUCCESS() {
+    // given
+    Long commentId = 1L;
+    Long replyCommentId = 10L;
+    String userEmail = "aa@aa.aa";
+    ReplyCommentReqDto replyCommentReqDto = new ReplyCommentReqDto();
+    replyCommentReqDto.setReplyComment("수정된 대댓글");
+
+    User user = User.builder()
+        .email(userEmail)
+        .build();
+    ReplyComment replyComment = ReplyComment.builder()
+        .id(replyCommentId)
+        .replyComment("기존 대댓글")
+        .user(user)
+        .comment(Comment.builder().id(commentId).build())
+        .build();
+
+    when(userService.findUserByEmail(userEmail)).thenReturn(user);
+    when(replyCommentRepository.findByIdAndCommentId(replyCommentId, commentId)).thenReturn(Optional.of(replyComment));
+
+    // when
+    replyCommentService.updateReplyComment(commentId, replyCommentId, replyCommentReqDto, mockPrincipal(userEmail));
+
+    // then
+    ArgumentCaptor<ReplyComment> replyCommentCaptor = ArgumentCaptor.forClass(ReplyComment.class);
+    verify(replyCommentRepository).save(replyCommentCaptor.capture());
+
+    ReplyComment updatedReplyComment = replyCommentCaptor.getValue();
+    assertEquals(replyCommentId, updatedReplyComment.getId());
+    assertEquals(user, updatedReplyComment.getUser());
+    assertEquals(replyCommentReqDto.getReplyComment(), updatedReplyComment.getReplyComment());
+  }
+
+  @Test
+  @DisplayName("대댓글 삭제 성공")
+  void deleteReplyComment_SUCCESS() {
+    // given
+    Long commentId = 1L;
+    Long replyCommentId = 10L;
+    String userEmail = "aa@aa.aa";
+    User user = User.builder()
+        .email(userEmail)
+        .build();
+    ReplyComment replyComment = ReplyComment.builder()
+        .id(replyCommentId)
+        .user(user)
+        .comment(Comment.builder().id(commentId).build())
+        .build();
+
+    when(userService.findUserByEmail(userEmail)).thenReturn(user);
+    when(replyCommentRepository.findByIdAndCommentId(replyCommentId, commentId)).thenReturn(Optional.of(replyComment));
+
+    // when
+    replyCommentService.deleteReplyComment(commentId, replyCommentId, mockPrincipal(userEmail));
+
+    // then
+    verify(replyCommentRepository).delete(replyComment);
+  }
+
+  private Principal mockPrincipal(String userEmail) {
+    return new Principal() {
+      @Override
+      public String getName() {
+        return userEmail;
+      }
+    };
+  }
+}

--- a/src/test/java/kr/zb/nengtul/comment/service/CommentServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/comment/service/CommentServiceTest.java
@@ -1,0 +1,232 @@
+package kr.zb.nengtul.comment.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import kr.zb.nengtul.comment.domain.dto.CommentGetDto;
+import kr.zb.nengtul.comment.domain.dto.CommentReqDto;
+import kr.zb.nengtul.comment.domain.entity.Comment;
+import kr.zb.nengtul.comment.domain.respository.CommentRepository;
+import kr.zb.nengtul.comment.replycomment.domain.dto.ReplyCommentGetDto;
+import kr.zb.nengtul.comment.replycomment.service.ReplyCommentService;
+import kr.zb.nengtul.recipe.domain.entity.RecipeDocument;
+import kr.zb.nengtul.recipe.domain.repository.RecipeSearchRepository;
+import kr.zb.nengtul.user.domain.entity.User;
+import kr.zb.nengtul.user.domain.repository.UserRepository;
+import kr.zb.nengtul.user.mailgun.client.MailgunClient;
+import kr.zb.nengtul.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import s3bucket.service.AmazonS3Service;
+
+class CommentServiceTest {
+
+  private CommentService commentService;
+  private RecipeSearchRepository recipeSearchRepository;
+  private CommentRepository commentRepository;
+  private UserService userService;
+  private ReplyCommentService replyCommentService;
+
+  @BeforeEach
+  void setUp() {
+    commentService = mock(CommentService.class);
+    recipeSearchRepository = mock(RecipeSearchRepository.class);
+    commentRepository = mock(CommentRepository.class);
+    userService = mock(UserService.class);
+    replyCommentService = mock(ReplyCommentService.class);
+
+    commentService = new CommentService(
+        recipeSearchRepository, commentRepository, userService, replyCommentService);
+  }
+
+
+  @Test
+  @DisplayName("댓글 작성 성공")
+  void createComment_SUCCESS() {
+    // given
+    String recipeId = "test_recipe_id";
+    String userEmail = "test@example.com";
+    CommentReqDto commentReqDto = new CommentReqDto();
+    commentReqDto.setComment("테스트 댓글");
+
+    User user = User.builder()
+        .email(userEmail)
+        .build();
+    RecipeDocument recipeDocument = RecipeDocument.builder()
+        .id(recipeId)
+        .build();
+
+    when(userService.findUserByEmail(userEmail)).thenReturn(user);
+    when(recipeSearchRepository.findById(recipeId)).thenReturn(Optional.of(recipeDocument));
+
+    Comment comment = Comment.builder()
+        .recipeId(recipeId)
+        .user(user)
+        .comment(commentReqDto.getComment())
+        .build();
+
+    when(commentRepository.save(any(Comment.class))).thenReturn(comment);
+
+    // when
+    commentService.createComment(recipeId, commentReqDto, mockPrincipal(userEmail));
+
+    // then
+    ArgumentCaptor<Comment> commentCaptor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository).save(commentCaptor.capture());
+
+    Comment capturedComment = commentCaptor.getValue();
+    assertEquals(recipeId, capturedComment.getRecipeId());
+    assertEquals(user, capturedComment.getUser());
+    assertEquals(commentReqDto.getComment(), capturedComment.getComment());
+  }
+
+
+  @Test
+  @DisplayName("댓글 수정 성공")
+  void updateComment_SUCCESS() {
+    // given
+    Long commentId = 1L;
+    String userEmail = "test@example.com";
+    CommentReqDto commentReqDto = new CommentReqDto();
+    commentReqDto.setComment("업데이트된 댓글");
+
+    User user = User.builder()
+        .email(userEmail)
+        .build();
+
+    Comment existingComment = Comment.builder()
+        .id(commentId)
+        .recipeId("test_recipe_id")
+        .user(user)
+        .comment("기존 댓글")
+        .build();
+
+    when(userService.findUserByEmail(userEmail)).thenReturn(user);
+    when(commentRepository.findByIdAndUser(commentId, user)).thenReturn(Optional.of(existingComment));
+
+    // when
+    commentService.updateComment(commentId, commentReqDto, mockPrincipal(userEmail));
+
+    // then
+    ArgumentCaptor<Comment> commentCaptor = ArgumentCaptor.forClass(Comment.class);
+    verify(commentRepository).save(commentCaptor.capture());
+
+    Comment updatedComment = commentCaptor.getValue();
+    assertEquals(commentId, updatedComment.getId());
+    assertEquals(existingComment.getRecipeId(), updatedComment.getRecipeId());
+    assertEquals(user, updatedComment.getUser());
+    assertEquals(commentReqDto.getComment(), updatedComment.getComment());
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 성공")
+  void deleteComment_SUCCESS() {
+    // given
+    Long commentId = 1L;
+    String userEmail = "test@example.com";
+
+    User user = User.builder()
+        .email(userEmail)
+        .build();
+
+    Comment existingComment = Comment.builder()
+        .id(commentId)
+        .recipeId("test_recipe_id")
+        .user(user)
+        .comment("삭제될 댓글")
+        .build();
+
+    // Mock 설정 (Mock setup)
+    when(userService.findUserByEmail(userEmail)).thenReturn(user);
+    when(commentRepository.findByIdAndUser(commentId, user)).thenReturn(Optional.of(existingComment));
+
+    // when
+    commentService.deleteComment(commentId, mockPrincipal(userEmail));
+
+    // then
+    verify(commentRepository).delete(existingComment);
+  }
+
+  @Test
+  @DisplayName("댓글 조회 성공")
+  void findAllCommentByRecipeId_SUCCESS() {
+    // given
+    String recipeId = "test_recipe_id";
+
+    User user = User.builder()
+        .nickname("test_user")
+        .build();
+
+    List<Comment> commentList = Arrays.asList(
+        Comment.builder()
+            .id(1L)
+            .recipeId(recipeId)
+            .user(user)
+            .comment("첫 번째 댓글")
+            .build(),
+        Comment.builder()
+            .id(2L)
+            .recipeId(recipeId)
+            .user(user)
+            .comment("두 번째 댓글")
+            .build()
+    );
+
+    when(recipeSearchRepository.findById(recipeId)).thenReturn(Optional.of(RecipeDocument.builder().id(recipeId).build()));
+    when(commentRepository.findAllByRecipeId(recipeId)).thenReturn(commentList);
+
+    List<ReplyCommentGetDto> replyCommentList = Arrays.asList(
+        ReplyCommentGetDto.builder().replyComment("첫 번째 대댓글").build(),
+        ReplyCommentGetDto.builder().replyComment("두 번째 대댓글").build()
+    );
+
+    when(replyCommentService.getReplyCommentByComment(1L)).thenReturn(replyCommentList);
+    when(replyCommentService.getReplyCommentByComment(2L)).thenReturn(Collections.emptyList());
+
+    // when
+    List<CommentGetDto> result = commentService.findAllCommentByRecipeId(recipeId);
+
+    // then
+    CommentGetDto firstComment = result.get(0);
+    assertEquals(recipeId, firstComment.getRecipeId());
+    assertEquals(1L, firstComment.getCommentId());
+    assertEquals(user.getId(), firstComment.getUserId());
+    assertEquals(user.getNickname(), firstComment.getUserNickname());
+    assertEquals("첫 번째 댓글", firstComment.getComment());
+    assertEquals(commentList.get(0).getCreatedAt(), firstComment.getCreatedAt());
+    assertEquals(commentList.get(0).getModifiedAt(), firstComment.getModifiedAt());
+
+    CommentGetDto secondComment = result.get(1);
+    assertEquals(recipeId, secondComment.getRecipeId());
+    assertEquals(2L, secondComment.getCommentId());
+    assertEquals(user.getId(), secondComment.getUserId());
+    assertEquals(user.getNickname(), secondComment.getUserNickname());
+    assertEquals("두 번째 댓글", secondComment.getComment());
+    assertEquals(commentList.get(1).getCreatedAt(), secondComment.getCreatedAt());
+    assertEquals(commentList.get(1).getModifiedAt(), secondComment.getModifiedAt());
+  }
+
+
+  private Principal mockPrincipal(String userEmail) {
+    return new Principal() {
+      @Override
+      public String getName() {
+        return userEmail;
+      }
+    };
+  }
+}


### PR DESCRIPTION
댓글 관련 경로 변경

dto에 대댓글 list 추가
```
private List<ReplyCommentGetDto> replyCommentGetDtoList;
```
content -> comment 변경

댓글 관련 페이징 처리 제거 

대댓글
대댓글은 상품에 대한 정보를 갖지 않으며, 댓글에 종속되어 조회시 함께 나오도록 구현

댓글/대댓글은 상품 조회시 상품에 대한 전체 댓글/대댓글이 나오기때문에 get 사용 X

errorCode에 댓글,대댓글 관련 오류 추가

토큰 관련 오류 발생시 401이 아닌 404가 발생하여 401 나오도록 수정
```
 public void checkAccessTokenAndAuthentication(HttpServletRequest request,
      HttpServletResponse response,
      FilterChain filterChain) throws ServletException, IOException {
    String accessToken = jwtTokenProvider.extractAccessToken(request).orElse(null);
    if (accessToken != null && jwtTokenProvider.isTokenValid(accessToken)) {
      // 토큰 검증, 토큰 유효할 때
      jwtTokenProvider.extractEmail(accessToken)
          .flatMap(userRepository::findByEmail)
          .ifPresent(this::saveAuthentication);
      filterChain.doFilter(request, response);
    } else {
      // 토큰 검증, 토큰 유효하지 않을 때 토큰 만료 메세지 출력
      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid access token");
    }
```

securityConfig 에 변경된 경로 추가

