### PR TITLE
feature/RecipeUpdate Logic 수정

### DIFF
--- a/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/entity/RecipeDocument.java
@@ -4,15 +4,19 @@ package kr.zb.nengtul.recipe.domain.entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import kr.zb.nengtul.recipe.domain.constants.RecipeCategory;
 import kr.zb.nengtul.recipe.domain.dto.RecipeUpdateDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.elasticsearch.annotations.*;
-
-import java.time.LocalDateTime;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -23,93 +27,66 @@ import java.time.LocalDateTime;
 @Mapping(mappingPath = "elasticsearch/recipe-mappings.json")
 public class RecipeDocument {
 
-    @Id
-    @Field(type = FieldType.Keyword)
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private String id;
+  @Id
+  @Field(type = FieldType.Keyword)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private String id;
 
-    @Field(type = FieldType.Keyword)
-    private Long userId;
+  @Field(type = FieldType.Keyword)
+  private Long userId;
 
-    @Field(type = FieldType.Text)
-    private String title;
+  @Field(type = FieldType.Text)
+  private String title;
 
-    @Field(type = FieldType.Keyword, index = false)
-    private String intro;
+  @Field(type = FieldType.Keyword, index = false)
+  private String intro;
 
-    @Field(type = FieldType.Text)
-    private String ingredient;
+  @Field(type = FieldType.Text)
+  private String ingredient;
 
-    @Field(type = FieldType.Keyword, index = false)
-    private String cookingStep;
+  @Field(type = FieldType.Keyword, index = false)
+  private String cookingStep;
 
-    @Field(type = FieldType.Keyword, index = false)
-    private String thumbnailUrl;
+  @Field(type = FieldType.Keyword, index = false)
+  private String thumbnailUrl;
 
-    @Field(type = FieldType.Keyword, index = false)
-    private String imageUrl;
+  @Field(type = FieldType.Keyword, index = false)
+  private String imageUrl;
 
-    @Field(type = FieldType.Keyword)
-    private String cookingTime;
+  @Field(type = FieldType.Keyword)
+  private String cookingTime;
 
-    @Field(type = FieldType.Keyword)
-    private String serving;
+  @Field(type = FieldType.Keyword)
+  private String serving;
 
-    @Field(type = FieldType.Keyword)
-    private RecipeCategory category;
+  @Field(type = FieldType.Keyword)
+  private RecipeCategory category;
 
-    @Field(type = FieldType.Keyword, index = false)
-    private String videoUrl;
+  @Field(type = FieldType.Keyword, index = false)
+  private String videoUrl;
 
-    @Field(type = FieldType.Integer)
-    private Long viewCount;
+  @Field(type = FieldType.Integer)
+  private Long viewCount;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute)
-    private LocalDateTime createdAt;
+  @Field(type = FieldType.Date, format = DateFormat.date_hour_minute)
+  private LocalDateTime createdAt;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute)
-    private LocalDateTime modifiedAt;
+  @Field(type = FieldType.Date, format = DateFormat.date_hour_minute)
+  private LocalDateTime modifiedAt;
 
-    public void updateViewCount() {
-        this.viewCount += 1;
-    }
+  public void updateViewCount() {
+    this.viewCount += 1;
+  }
 
-    public void updateRecipe(RecipeUpdateDto recipeUpdateDto) {
-
-        if (!recipeUpdateDto.getTitle().isEmpty()) {
-            this.title = recipeUpdateDto.getTitle();
-        }
-
-        if (!recipeUpdateDto.getIntro().isEmpty()) {
-            this.ingredient = recipeUpdateDto.getIntro();
-        }
-
-        if (!recipeUpdateDto.getIngredient().isEmpty()) {
-            this.ingredient = recipeUpdateDto.getIngredient();
-        }
-
-        if (!recipeUpdateDto.getCookingStep().isEmpty()) {
-            this.cookingStep = recipeUpdateDto.getCookingStep();
-        }
-
-        if (!recipeUpdateDto.getCookingTime().isEmpty()) {
-            this.cookingTime = recipeUpdateDto.getCookingTime();
-        }
-
-        if (!recipeUpdateDto.getServing().isEmpty()) {
-            this.serving = recipeUpdateDto.getServing();
-        }
-
-        if (!recipeUpdateDto.getCategory().equals(RecipeCategory.NONE)) {
-            this.category = recipeUpdateDto.getCategory();
-        }
-
-        if (!recipeUpdateDto.getVideoUrl().isEmpty()) {
-            this.videoUrl = recipeUpdateDto.getVideoUrl();
-        }
-
-        this.modifiedAt = LocalDateTime.now();
-
-    }
+  public void updateRecipe(RecipeUpdateDto recipeUpdateDto) {
+    this.title = recipeUpdateDto.getTitle();
+    this.intro = recipeUpdateDto.getIntro();
+    this.ingredient = recipeUpdateDto.getIngredient();
+    this.cookingStep = recipeUpdateDto.getCookingStep();
+    this.cookingTime = recipeUpdateDto.getCookingTime();
+    this.serving = recipeUpdateDto.getServing();
+    this.category = recipeUpdateDto.getCategory();
+    this.videoUrl = recipeUpdateDto.getVideoUrl();
+  }
 
 }


### PR DESCRIPTION
Recipe 수정
---
프론트엔드 부분에서 기존에 기재했던 부분을 다 불러온 뒤 수정을 진행하기 때문에 RecipeDocument 수정 시에 isEmpty로 비었는지 확인하는 로직이 불필요해졌기 때문에 삭제