### PR TITLE
Feature/likes,favorite add user point

### DIFF
--- a/src/main/java/kr/zb/nengtul/favorite/service/FavoriteService.java
+++ b/src/main/java/kr/zb/nengtul/favorite/service/FavoriteService.java
@@ -5,6 +5,7 @@ import kr.zb.nengtul.favorite.domain.entity.Favorite;
 import kr.zb.nengtul.favorite.domain.repository.FavoriteRepository;
 import kr.zb.nengtul.global.exception.CustomException;
 import kr.zb.nengtul.global.exception.ErrorCode;
+import kr.zb.nengtul.user.domain.constants.UserPoint;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,10 @@ public class FavoriteService {
                 .ifPresent(favorite -> {
                     throw new CustomException(ErrorCode.ALREADY_ADDED_FAVORITE);
                 });
+
+        publisher.setPlusPoint(UserPoint.FAVORITE);
+
+        userRepository.save(publisher);
 
         favoriteRepository.save(Favorite.builder()
                 .user(user)
@@ -70,6 +75,10 @@ public class FavoriteService {
         if (!user.getId().equals(favorite.getUser().getId())) {
             throw new CustomException(ErrorCode.NO_PERMISSION);
         }
+
+        favorite.getPublisher().setMinusPoint(UserPoint.FAVORITE);
+
+        userRepository.save(favorite.getPublisher());
 
         favoriteRepository.delete(favorite);
 

--- a/src/main/java/kr/zb/nengtul/user/domain/constants/UserPoint.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/constants/UserPoint.java
@@ -1,0 +1,16 @@
+package kr.zb.nengtul.user.domain.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum UserPoint {
+
+  LIKES(1),
+  FAVORITE(3);
+
+  final int point;
+
+  UserPoint(int point) {
+    this.point = point;
+  }
+}

--- a/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
+++ b/src/main/java/kr/zb/nengtul/user/domain/entity/User.java
@@ -19,11 +19,11 @@ import kr.zb.nengtul.global.entity.ProviderType;
 import kr.zb.nengtul.global.entity.RoleType;
 import kr.zb.nengtul.notice.domain.entity.Notice;
 import kr.zb.nengtul.shareboard.domain.entity.ShareBoard;
+import kr.zb.nengtul.user.domain.constants.UserPoint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.UniqueElements;
 
 @Getter
 @NoArgsConstructor
@@ -179,6 +179,14 @@ public class User extends BaseTimeEntity {
 
   public void setPointAddShardBoard(int point) {
     this.point += 3;
+  }
+
+  public void setPlusPoint(UserPoint userPoint) {
+    this.point += userPoint.getPoint();
+  }
+
+  public void setMinusPoint(UserPoint userPoint) {
+    this.point -= userPoint.getPoint();
   }
 
   public boolean isEmailVerifiedYn() {

--- a/src/test/java/kr/zb/nengtul/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/favorite/service/FavoriteServiceTest.java
@@ -5,6 +5,7 @@ import kr.zb.nengtul.favorite.domain.entity.Favorite;
 import kr.zb.nengtul.favorite.domain.repository.FavoriteRepository;
 import kr.zb.nengtul.global.exception.CustomException;
 import kr.zb.nengtul.global.exception.ErrorCode;
+import kr.zb.nengtul.user.domain.constants.UserPoint;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.*;
@@ -44,10 +45,12 @@ class FavoriteServiceTest {
     @DisplayName("즐겨찾기 등록 성공")
     void addFavorite_SUCCESS() {
         //given
+        User publisher = User.builder().build();
+
         when(userRepository.findByEmail(any()))
                 .thenReturn(Optional.of(new User()));
         when(userRepository.findById(any()))
-                .thenReturn(Optional.of(new User()));
+                .thenReturn(Optional.of(publisher));
 
         Principal principal =
                 new UsernamePasswordAuthenticationToken("test@test.com", null);
@@ -58,6 +61,7 @@ class FavoriteServiceTest {
         //then
         verify(favoriteRepository, times(1))
                 .save(any(Favorite.class));
+        assertEquals(publisher.getPoint(), UserPoint.FAVORITE.getPoint());
     }
 
     @Test
@@ -125,13 +129,18 @@ class FavoriteServiceTest {
     void deleteFavorite_SUCCESS() {
         //given
         User user = mock(User.class);
+        User publisher = new User();
+        publisher.setPlusPoint(UserPoint.FAVORITE);
         when(user.getId())
                 .thenReturn(1L);
         when(userRepository.findByEmail(any()))
                 .thenReturn(Optional.of(user));
         when(favoriteRepository.findById(any()))
                 .thenReturn(Optional.of(
-                        Favorite.builder().user(user).build()));
+                        Favorite.builder()
+                            .user(user)
+                            .publisher(publisher)
+                            .build()));
 
         Principal principal =
                 new UsernamePasswordAuthenticationToken("test@test.com", null);
@@ -142,6 +151,7 @@ class FavoriteServiceTest {
         //then
         verify(favoriteRepository, times(1))
                 .delete(any(Favorite.class));
+        assertEquals(publisher.getPoint(), 0);
     }
 
     @Test

--- a/src/test/java/kr/zb/nengtul/likes/service/LikesServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/likes/service/LikesServiceTest.java
@@ -19,6 +19,7 @@ import kr.zb.nengtul.likes.domain.entity.Likes;
 import kr.zb.nengtul.likes.domain.repository.LikesRepository;
 import kr.zb.nengtul.recipe.domain.entity.RecipeDocument;
 import kr.zb.nengtul.recipe.domain.repository.RecipeSearchRepository;
+import kr.zb.nengtul.user.domain.constants.UserPoint;
 import kr.zb.nengtul.user.domain.entity.User;
 import kr.zb.nengtul.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
@@ -55,11 +56,16 @@ class LikesServiceTest {
   @DisplayName("좋아요 등록 성공")
   void addLikes_SUCCESS() {
     //given
+    User publisher = new User();
+
     when(userRepository.findByEmail(any()))
         .thenReturn(Optional.of(new User()));
 
     when(recipeSearchRepository.findById(any()))
         .thenReturn(Optional.of(new RecipeDocument()));
+
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(publisher));
 
     Principal principal = new UsernamePasswordAuthenticationToken(
         "test@test.com", null);
@@ -70,6 +76,7 @@ class LikesServiceTest {
     //then
     verify(likesRepository, times(1))
         .save(any(Likes.class));
+    assertEquals(publisher.getPoint(), UserPoint.LIKES.getPoint());
   }
 
   @Test
@@ -144,6 +151,8 @@ class LikesServiceTest {
   void deleteLikes_SUCCESS() {
     //given
     User user = mock(User.class);
+    User publisher = new User();
+    publisher.setPlusPoint(UserPoint.LIKES);
 
     Likes likes = Likes.builder().user(user).build();
 
@@ -152,6 +161,12 @@ class LikesServiceTest {
 
     when(likesRepository.findById(any()))
         .thenReturn(Optional.of(likes));
+
+    when(recipeSearchRepository.findById(any()))
+        .thenReturn(Optional.of(new RecipeDocument()));
+
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(publisher));
 
     when(user.getId())
         .thenReturn(1L);
@@ -165,6 +180,7 @@ class LikesServiceTest {
     //then
     verify(likesRepository, times(1))
         .delete(any(Likes.class));
+    assertEquals(publisher.getPoint(), 0);
   }
 
 


### PR DESCRIPTION
Likes, Favorite - User Point
---
- 좋아요와 즐겨찾기 등록 시 그 게시물의 유저의 포인트가 올라가는 로직을 추가했습니다.
포인트는 UserPoint로 따로 Enum 값을 만들어서 포인트의 배점을 다르게 할 시 유지보수하기 편하도록 하였습니다.

테스트  코드
---
- 좋아요와 즐겨찾기 등록 및 취소 시 포인트 변경되는 부분 테스트코드에 적용