### PR TITLE
feature/S3Bucket File Size Change

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,8 +76,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 1MB # 요청한 파일 한 개의 크기
-      max-request-size: 1MB # 요청한 파일 전체의 크기
+      max-file-size: 2MB # 요청한 파일 한 개의 크기
+      max-request-size: 15MB # 요청한 파일 전체의 크기
 
 cloud:
   aws:


### PR DESCRIPTION
Bucket 요청 파일 최대 사이즈 설정 변경
---
레시피에 사진을 넣고 요청 시 설정되어 있는 최대 사이즈가 너무 작아서 요청이 에러가 나는 경우가 있어 설정 변경합니다.

변경 전
- 파일 한 개 최대 사이즈 : 1MB
- 한 번 요청 최대 사이즈 : 1MB

변경 후
- 파일 한 개 최대 사이즈 : 2MB
- 한 번 요청 최대 사이즈 : 15MB