### PR TITLE
feature/Recipe GetDetailDto 수정

### DIFF
--- a/src/main/java/kr/zb/nengtul/likes/service/LikesService.java
+++ b/src/main/java/kr/zb/nengtul/likes/service/LikesService.java
@@ -92,15 +92,14 @@ public class LikesService {
       throw new CustomException(ErrorCode.NO_PERMISSION);
     }
 
-    RecipeDocument recipeDocument = recipeSearchRepository.findById(likes.getRecipeId())
-        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
+    recipeSearchRepository.findById(likes.getRecipeId())
+        .ifPresent(recipe -> {
+          User publisher = userRepository.findById(recipe.getUserId())
+              .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
-    User publisher = userRepository.findById(recipeDocument.getUserId())
-        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-    
-    publisher.setMinusPoint(UserPoint.LIKES);
-
-    userRepository.save(publisher);
+          publisher.setMinusPoint(UserPoint.LIKES);
+          userRepository.save(publisher);
+        });
 
     likesRepository.delete(likes);
   }

--- a/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeGetDetailDto.java
+++ b/src/main/java/kr/zb/nengtul/recipe/domain/dto/RecipeGetDetailDto.java
@@ -40,6 +40,10 @@ public class RecipeGetDetailDto {
 
     private Long viewCount;
 
+    private String userProfileUrl;
+
+    private int point;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime modifiedAt;

--- a/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
+++ b/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
@@ -113,8 +113,12 @@ public class RecipeService {
                 RecipeGetDetailDto.fromRecipeDocument(recipeDocument);
 
         User user = userRepository.findById(recipeDocument.getUserId())
-                .orElseGet(() -> User.builder().nickname("냉장고를털어라").build());
+                .orElseGet(() -> User.builder()
+                    .profileImageUrl("")
+                    .nickname("냉장고를털어라").build());
 
+        recipeGetDetailDto.setUserProfileUrl(user.getProfileImageUrl());
+        recipeGetDetailDto.setPoint(user.getPoint());
         recipeGetDetailDto.setNickName(user.getNickname());
 
         return recipeGetDetailDto;


### PR DESCRIPTION
Recipe GetDetail
---
프론트엔드 요청으로 레시피 상세 조회에 유저 포인트, 유저 프로필 URL 추가

Likes 취소
---
레시피 좋아요 취소 시 레시피를 작성한 사용자의 포인트를 내리기 위해서 레시피를 조회하는 로직이 있는데, 이 때 레시피가 없으면 NOT_FOUND_RECIPE 예외가 발생하여 좋아요 취소가 되지 않은 부분을 발견하여 해당 부분 수정하였습니다.