### PR TITLE
feature/RecipeService_Empty_User_Update

### DIFF
--- a/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
+++ b/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
@@ -112,9 +112,7 @@ public class RecipeService {
                 RecipeGetDetailDto.fromRecipeDocument(recipeDocument);
 
         User user = userRepository.findById(recipeDocument.getUserId())
-                .orElseGet(() -> User.builder()
-                    .profileImageUrl("")
-                    .nickname("냉장고를털어라").build());
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         recipeGetDetailDto.setUserProfileUrl(user.getProfileImageUrl());
         recipeGetDetailDto.setPoint(user.getPoint());
@@ -201,9 +199,7 @@ public class RecipeService {
                 RecipeGetListDto.fromRecipeDocument(recipeDocument);
 
         User user = userRepository.findById(recipeDocument.getUserId())
-                .orElseGet(() -> User.builder()
-                        .nickname("냉장고를털어라")
-                        .build());
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         Long likeCount = likesRepository.countByRecipeId(recipeDocument.getId());
 

--- a/src/test/java/kr/zb/nengtul/recipe/service/RecipeServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/recipe/service/RecipeServiceTest.java
@@ -167,6 +167,8 @@ class RecipeServiceTest {
 
         when(recipeSearchRepository.findAll(pageable))
                 .thenReturn(new PageImpl<>(recipeDocuments));
+        when(userRepository.findById(any()))
+            .thenReturn(Optional.of(new User()));
 
         //when
         Page<RecipeGetListDto> allRecipe = recipeService.getAllRecipe(pageable);
@@ -198,6 +200,8 @@ class RecipeServiceTest {
 
         when(recipeSearchRepository.findById(any()))
                 .thenReturn(Optional.of(recipeDocument));
+        when(userRepository.findById(any()))
+            .thenReturn(Optional.of(new User()));
 
         //when
         RecipeGetDetailDto recipeDetailById = recipeService.getRecipeDetailById(any());
@@ -227,6 +231,8 @@ class RecipeServiceTest {
 
         when(recipeSearchRepository.findAllByCategory(RecipeCategory.BREAD, pageable))
                 .thenReturn(new PageImpl<>(recipeDocuments));
+        when(userRepository.findById(any()))
+            .thenReturn(Optional.of(new User()));
 
         //when
         Page<RecipeGetListDto> allRecipe =
@@ -246,6 +252,8 @@ class RecipeServiceTest {
 
         when(recipeSearchRepository.findAllByTitle("title", pageable))
                 .thenReturn(new PageImpl<>(recipeDocuments));
+        when(userRepository.findById(any()))
+            .thenReturn(Optional.of(new User()));
 
         //when
         Page<RecipeGetListDto> allRecipe =
@@ -265,6 +273,8 @@ class RecipeServiceTest {
 
         when(recipeSearchRepository.findAllByIngredient("ingredient", pageable))
                 .thenReturn(new PageImpl<>(recipeDocuments));
+        when(userRepository.findById(any()))
+            .thenReturn(Optional.of(new User()));
 
         //when
         Page<RecipeGetListDto> allRecipe =


### PR DESCRIPTION
Recipe 조회 시 User ElseGet 수정
---
- 레시피 조회 시 유저를 조회하는 부분에서 탈퇴한 사용자가 있을 시 
orElseGet으로 User 빌드하여 필요한 부분을 더미 데이터를 넣어서 생성했던 부분 수정하였습니다.
이유 : 탈퇴 시 탈퇴한 유저의 게시물, 게시판 등 고스트 유저로 덮어씌워 NOT_FOUND_USER가 발생하지 않도록 수정됨

테스트코드
---
- 로직 바뀐 것에 대한 부분 테스트코드 수정