### PR TITLE
ADMIN 계정 - 레시피 삭제 권한 부여

### DIFF
--- a/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
+++ b/src/main/java/kr/zb/nengtul/recipe/service/RecipeService.java
@@ -1,5 +1,11 @@
 package kr.zb.nengtul.recipe.service;
 
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import kr.zb.nengtul.global.entity.RoleType;
 import kr.zb.nengtul.global.exception.CustomException;
 import kr.zb.nengtul.global.exception.ErrorCode;
 import kr.zb.nengtul.likes.domain.repository.LikesRepository;
@@ -20,205 +26,175 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import s3bucket.service.AmazonS3Service;
 
-import java.security.Principal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 public class RecipeService {
 
-    private final RecipeSearchRepository recipeSearchRepository;
+  private final RecipeSearchRepository recipeSearchRepository;
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
-    private final LikesRepository likesRepository;
+  private final LikesRepository likesRepository;
 
-    private final AmazonS3Service amazonS3Service;
+  private final AmazonS3Service amazonS3Service;
 
-    public void addRecipe(Principal principal, RecipeAddDto recipeAddDto,
-                          List<MultipartFile> images, MultipartFile thumbnail) {
+  public void addRecipe(Principal principal, RecipeAddDto recipeAddDto,
+      List<MultipartFile> images, MultipartFile thumbnail) {
 
-        User user = userRepository.findByEmail(principal.getName()).
-                orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    User user = userRepository.findByEmail(principal.getName()).
+        orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
-        String uuid = UUID.randomUUID().toString();
+    String uuid = UUID.randomUUID().toString();
 
-        recipeSearchRepository.save(RecipeDocument.builder()
-                .userId(user.getId())
-                .title(recipeAddDto.getTitle())
-                .intro(recipeAddDto.getIntro())
-                .ingredient(recipeAddDto.getIngredient())
-                .cookingStep(recipeAddDto.getCookingStep())
-                .imageUrl(
-                        amazonS3Service.uploadFileForRecipeCookingStep(images, uuid)
-                )
-                .thumbnailUrl(
-                        amazonS3Service.uploadFileForRecipeThumbnail(thumbnail, uuid)
-                )
-                .cookingTime(recipeAddDto.getCookingTime())
-                .serving(recipeAddDto.getServing())
-                .category(recipeAddDto.getCategory())
-                .videoUrl(recipeAddDto.getVideoUrl())
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .build());
+    recipeSearchRepository.save(RecipeDocument.builder()
+        .userId(user.getId())
+        .title(recipeAddDto.getTitle())
+        .intro(recipeAddDto.getIntro())
+        .ingredient(recipeAddDto.getIngredient())
+        .cookingStep(recipeAddDto.getCookingStep())
+        .imageUrl(
+            amazonS3Service.uploadFileForRecipeCookingStep(images, uuid)
+        )
+        .thumbnailUrl(
+            amazonS3Service.uploadFileForRecipeThumbnail(thumbnail, uuid)
+        )
+        .cookingTime(recipeAddDto.getCookingTime())
+        .serving(recipeAddDto.getServing())
+        .category(recipeAddDto.getCategory())
+        .videoUrl(recipeAddDto.getVideoUrl())
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .build());
 
+  }
+
+  public Page<RecipeGetListDto> getAllRecipe(Pageable pageable) {
+
+    return recipeSearchRepository.findAll(pageable)
+        .map(this::settingRecipeGetListDto);
+  }
+
+  public RecipeGetDetailDto getRecipeDetailById(String recipeId) {
+
+    RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
+
+    recipeDocument.updateViewCount();
+    recipeSearchRepository.save(recipeDocument);
+
+    RecipeGetDetailDto recipeGetDetailDto =
+        RecipeGetDetailDto.fromRecipeDocument(recipeDocument);
+
+    User user = userRepository.findById(recipeDocument.getUserId())
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    recipeGetDetailDto.setUserProfileUrl(user.getProfileImageUrl());
+    recipeGetDetailDto.setPoint(user.getPoint());
+    recipeGetDetailDto.setNickName(user.getNickname());
+
+    return recipeGetDetailDto;
+  }
+
+  public Page<RecipeGetListDto> getRecipeByCategory(RecipeCategory category, Pageable pageable) {
+
+    return recipeSearchRepository.findAllByCategory(category, pageable)
+        .map(this::settingRecipeGetListDto);
+  }
+
+  public Page<RecipeGetListDto> getRecipeByTitle(String title, Pageable pageable) {
+
+    return recipeSearchRepository.findAllByTitle(title, pageable)
+        .map(this::settingRecipeGetListDto);
+  }
+
+  public Page<RecipeGetListDto> getRecipeByIngredient(String ingredient, Pageable pageable) {
+
+    return recipeSearchRepository.findAllByIngredient(ingredient, pageable)
+        .map(this::settingRecipeGetListDto);
+  }
+
+  @Transactional
+  public void updateRecipe(
+      Principal principal, String recipeId, RecipeUpdateDto recipeUpdateDto,
+      List<MultipartFile> images, MultipartFile thumbnail) {
+
+    User user = userRepository.findByEmail(principal.getName())
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
+
+    if (!Objects.equals(user.getId(), recipeDocument.getUserId())) {
+      throw new CustomException(ErrorCode.NO_PERMISSION);
     }
 
-    public void addRecipeForCrawling(Principal principal, RecipeAddDto recipeAddDto,
-                                     String images, String thumbnail) {
-
-        User user = userRepository.findByEmail(principal.getName()).
-                orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        recipeSearchRepository.save(RecipeDocument.builder()
-                .userId(user.getId())
-                .title(recipeAddDto.getTitle())
-                .intro(recipeAddDto.getIntro())
-                .ingredient(recipeAddDto.getIngredient())
-                .cookingStep(recipeAddDto.getCookingStep())
-                .imageUrl(images)
-                .thumbnailUrl(thumbnail)
-                .cookingTime(recipeAddDto.getCookingTime())
-                .serving(recipeAddDto.getServing())
-                .category(recipeAddDto.getCategory())
-                .videoUrl(recipeAddDto.getVideoUrl())
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .build());
-
+    if (!thumbnail.isEmpty()) {
+      amazonS3Service.updateFile(thumbnail, recipeDocument.getThumbnailUrl());
     }
 
-    public Page<RecipeGetListDto> getAllRecipe(Pageable pageable) {
+    if (!recipeUpdateDto.getImagesUrl().isEmpty() &&
+        !images.get(0).isEmpty()) {
 
-        return recipeSearchRepository.findAll(pageable)
-                .map(this::settingRecipeGetListDto);
+      String[] imageUrlArr = recipeUpdateDto.getImagesUrl().split("\\\\");
+
+      for (int i = 0; i < imageUrlArr.length; i++) {
+        amazonS3Service.updateFile(images.get(i), imageUrlArr[i]);
+      }
     }
 
-    public RecipeGetDetailDto getRecipeDetailById(String recipeId) {
+    recipeDocument.updateRecipe(recipeUpdateDto);
 
-        RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
+    recipeSearchRepository.save(recipeDocument);
+  }
 
-        recipeDocument.updateViewCount();
-        recipeSearchRepository.save(recipeDocument);
 
-        RecipeGetDetailDto recipeGetDetailDto =
-                RecipeGetDetailDto.fromRecipeDocument(recipeDocument);
+  @Transactional
+  public void deleteRecipe(Principal principal, String recipeId) {
 
-        User user = userRepository.findById(recipeDocument.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    User user = userRepository.findByEmail(principal.getName())
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
-        recipeGetDetailDto.setUserProfileUrl(user.getProfileImageUrl());
-        recipeGetDetailDto.setPoint(user.getPoint());
-        recipeGetDetailDto.setNickName(user.getNickname());
+    RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
 
-        return recipeGetDetailDto;
+    if (!Objects.equals(user.getId(), recipeDocument.getUserId()) &&
+        !user.getRoles().equals(RoleType.ADMIN)) {
+      throw new CustomException(ErrorCode.NO_PERMISSION);
     }
 
-    public Page<RecipeGetListDto> getRecipeByCategory(RecipeCategory category, Pageable pageable) {
+    deleteRecipeS3UploadFile(
+        recipeDocument.getImageUrl(), recipeDocument.getThumbnailUrl());
 
-        return recipeSearchRepository.findAllByCategory(category, pageable)
-                .map(this::settingRecipeGetListDto);
+    recipeSearchRepository.delete(recipeDocument);
+  }
+
+  private RecipeGetListDto settingRecipeGetListDto(RecipeDocument recipeDocument) {
+
+    RecipeGetListDto recipeGetListDto =
+        RecipeGetListDto.fromRecipeDocument(recipeDocument);
+
+    User user = userRepository.findById(recipeDocument.getUserId())
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    Long likeCount = likesRepository.countByRecipeId(recipeDocument.getId());
+
+    recipeGetListDto.setNickName(user.getNickname());
+    recipeGetListDto.setLikeCount(likeCount);
+
+    return recipeGetListDto;
+  }
+
+  private void deleteRecipeS3UploadFile(String imagesUrl, String thumbnailUrl) {
+
+    amazonS3Service.deleteFile(thumbnailUrl);
+
+    String[] imagesUrlArr = imagesUrl.split("\\\\");
+
+    for (String imageUrl : imagesUrlArr) {
+      amazonS3Service.deleteFile(imageUrl);
     }
-
-    public Page<RecipeGetListDto> getRecipeByTitle(String title, Pageable pageable) {
-
-        return recipeSearchRepository.findAllByTitle(title, pageable)
-                .map(this::settingRecipeGetListDto);
-    }
-
-    public Page<RecipeGetListDto> getRecipeByIngredient(String ingredient, Pageable pageable) {
-
-        return recipeSearchRepository.findAllByIngredient(ingredient, pageable)
-                .map(this::settingRecipeGetListDto);
-    }
-
-    @Transactional
-    public void updateRecipe(
-            Principal principal, String recipeId, RecipeUpdateDto recipeUpdateDto,
-            List<MultipartFile> images, MultipartFile thumbnail) {
-
-        User user = userRepository.findByEmail(principal.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
-
-        if (!Objects.equals(user.getId(), recipeDocument.getUserId())) {
-            throw new CustomException(ErrorCode.NO_PERMISSION);
-        }
-
-        if (!thumbnail.isEmpty()) {
-            amazonS3Service.updateFile(thumbnail, recipeDocument.getThumbnailUrl());
-        }
-
-        if (!recipeUpdateDto.getImagesUrl().isEmpty() &&
-                !images.get(0).isEmpty()) {
-
-            String[] imageUrlArr = recipeUpdateDto.getImagesUrl().split("\\\\");
-
-            for (int i = 0; i < imageUrlArr.length; i++) {
-                amazonS3Service.updateFile(images.get(i), imageUrlArr[i]);
-            }
-        }
-
-        recipeDocument.updateRecipe(recipeUpdateDto);
-
-        recipeSearchRepository.save(recipeDocument);
-    }
-
-
-    @Transactional
-    public void deleteRecipe(Principal principal, String recipeId) {
-
-        User user = userRepository.findByEmail(principal.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        RecipeDocument recipeDocument = recipeSearchRepository.findById(recipeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECIPE));
-
-        if (!Objects.equals(user.getId(), recipeDocument.getUserId())) {
-            throw new CustomException(ErrorCode.NO_PERMISSION);
-        }
-
-        deleteRecipeS3UploadFile(
-                recipeDocument.getImageUrl(), recipeDocument.getThumbnailUrl());
-
-        recipeSearchRepository.delete(recipeDocument);
-    }
-
-    private RecipeGetListDto settingRecipeGetListDto(RecipeDocument recipeDocument) {
-
-        RecipeGetListDto recipeGetListDto =
-                RecipeGetListDto.fromRecipeDocument(recipeDocument);
-
-        User user = userRepository.findById(recipeDocument.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        Long likeCount = likesRepository.countByRecipeId(recipeDocument.getId());
-
-        recipeGetListDto.setNickName(user.getNickname());
-        recipeGetListDto.setLikeCount(likeCount);
-
-        return recipeGetListDto;
-    }
-
-    private void deleteRecipeS3UploadFile(String imagesUrl, String thumbnailUrl) {
-
-        amazonS3Service.deleteFile(thumbnailUrl);
-
-        String[] imagesUrlArr = imagesUrl.split("\\\\");
-
-        for (String imageUrl : imagesUrlArr) {
-            amazonS3Service.deleteFile(imageUrl);
-        }
-    }
+  }
 
 
 }

--- a/src/test/java/kr/zb/nengtul/recipe/service/RecipeServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/recipe/service/RecipeServiceTest.java
@@ -1,5 +1,24 @@
 package kr.zb.nengtul.recipe.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import kr.zb.nengtul.global.entity.RoleType;
+import kr.zb.nengtul.global.exception.CustomException;
+import kr.zb.nengtul.global.exception.ErrorCode;
 import kr.zb.nengtul.likes.domain.repository.LikesRepository;
 import kr.zb.nengtul.recipe.domain.constants.RecipeCategory;
 import kr.zb.nengtul.recipe.domain.dto.RecipeAddDto;
@@ -20,366 +39,419 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.web.multipart.MultipartFile;
 import s3bucket.service.AmazonS3Service;
 
-import java.security.Principal;
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
-
 @DisplayName("레시피 서비스 테스트")
 class RecipeServiceTest {
 
-    private RecipeService recipeService;
+  private RecipeService recipeService;
 
-    private RecipeSearchRepository recipeSearchRepository;
+  private RecipeSearchRepository recipeSearchRepository;
 
-    private UserRepository userRepository;
+  private UserRepository userRepository;
 
-    private AmazonS3Service amazonS3Service;
+  private AmazonS3Service amazonS3Service;
 
-    private LikesRepository likesRepository;
+  private LikesRepository likesRepository;
 
-    private List<RecipeDocument> recipeDocuments;
+  private List<RecipeDocument> recipeDocuments;
 
-    @BeforeEach
-    void setUp() {
-        // Mock 객체 초기화
-        recipeSearchRepository = mock(RecipeSearchRepository.class);
-        amazonS3Service = mock(AmazonS3Service.class);
-        userRepository = mock(UserRepository.class);
-        likesRepository = mock(LikesRepository.class);
+  @BeforeEach
+  void setUp() {
+    // Mock 객체 초기화
+    recipeSearchRepository = mock(RecipeSearchRepository.class);
+    amazonS3Service = mock(AmazonS3Service.class);
+    userRepository = mock(UserRepository.class);
+    likesRepository = mock(LikesRepository.class);
 
-        recipeService = new RecipeService(
-                recipeSearchRepository, userRepository, likesRepository, amazonS3Service);
+    recipeService = new RecipeService(
+        recipeSearchRepository, userRepository, likesRepository, amazonS3Service);
 
-        recipeDocuments = new ArrayList<>();
+    recipeDocuments = new ArrayList<>();
 
-        recipeDocuments.add(RecipeDocument.builder()
-                .id("userId1")
-                .userId(1L)
-                .title("테스트 타이틀 1")
-                .intro("테스트 인트로 1")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl1")
-                .cookingTime("30분")
-                .serving("1인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build());
+    recipeDocuments.add(RecipeDocument.builder()
+        .id("userId1")
+        .userId(1L)
+        .title("테스트 타이틀 1")
+        .intro("테스트 인트로 1")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl1")
+        .cookingTime("30분")
+        .serving("1인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build());
 
-        recipeDocuments.add(RecipeDocument.builder()
-                .id("userId2")
-                .userId(2L)
-                .title("테스트 타이틀 2")
-                .intro("테스트 인트로 2")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl2")
-                .cookingTime("30분")
-                .serving("2인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build());
+    recipeDocuments.add(RecipeDocument.builder()
+        .id("userId2")
+        .userId(2L)
+        .title("테스트 타이틀 2")
+        .intro("테스트 인트로 2")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl2")
+        .cookingTime("30분")
+        .serving("2인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build());
 
-        recipeDocuments.add(RecipeDocument.builder()
-                .id("userId3")
-                .userId(3L)
-                .title("테스트 타이틀 3")
-                .intro("테스트 인트로 3")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl3")
-                .cookingTime("30분")
-                .serving("3인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build());
+    recipeDocuments.add(RecipeDocument.builder()
+        .id("userId3")
+        .userId(3L)
+        .title("테스트 타이틀 3")
+        .intro("테스트 인트로 3")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl3")
+        .cookingTime("30분")
+        .serving("3인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build());
 
-        recipeDocuments.add(RecipeDocument.builder()
-                .id("userId4")
-                .userId(4L)
-                .title("테스트 타이틀 4")
-                .intro("테스트 인트로 4")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl4")
-                .cookingTime("30분")
-                .serving("4인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build());
+    recipeDocuments.add(RecipeDocument.builder()
+        .id("userId4")
+        .userId(4L)
+        .title("테스트 타이틀 4")
+        .intro("테스트 인트로 4")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl4")
+        .cookingTime("30분")
+        .serving("4인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build());
 
-        recipeDocuments.add(RecipeDocument.builder()
-                .id("userId5")
-                .userId(5L)
-                .title("테스트 타이틀 5")
-                .intro("테스트 인트로 5")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl1")
-                .cookingTime("30분")
-                .serving("5인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build());
-    }
+    recipeDocuments.add(RecipeDocument.builder()
+        .id("userId5")
+        .userId(5L)
+        .title("테스트 타이틀 5")
+        .intro("테스트 인트로 5")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl1")
+        .cookingTime("30분")
+        .serving("5인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build());
+  }
 
-    @Test
-    @DisplayName("레시피 추가 테스트")
-    void addRecipe() {
-        //given
-        RecipeAddDto recipeAddDto = new RecipeAddDto();
-        List<MultipartFile> images = Collections.singletonList(mock(MultipartFile.class));
-        MultipartFile thumbnail = mock(MultipartFile.class);
+  @Test
+  @DisplayName("레시피 추가 테스트")
+  void addRecipe() {
+    //given
+    RecipeAddDto recipeAddDto = new RecipeAddDto();
+    List<MultipartFile> images = Collections.singletonList(mock(MultipartFile.class));
+    MultipartFile thumbnail = mock(MultipartFile.class);
 
-        User user = new User();
+    User user = new User();
 
-        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+    when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
 
-        when(amazonS3Service.uploadFileForRecipeCookingStep(anyList(), anyString()))
-                .thenReturn("image_url");
+    when(amazonS3Service.uploadFileForRecipeCookingStep(anyList(), anyString()))
+        .thenReturn("image_url");
 
-        //when
-        recipeService.addRecipe(mock(Principal.class), recipeAddDto, images, thumbnail);
+    //when
+    recipeService.addRecipe(mock(Principal.class), recipeAddDto, images, thumbnail);
 
-        //then
-        verify(recipeSearchRepository, times(1))
-                .save(any(RecipeDocument.class));
-    }
+    //then
+    verify(recipeSearchRepository, times(1))
+        .save(any(RecipeDocument.class));
+  }
 
-    @Test
-    @DisplayName("레시피 전체 리스트 가져오기")
-    void getAllRecipe() {
-        //given
-        Pageable pageable = Pageable.ofSize(20);
+  @Test
+  @DisplayName("레시피 전체 리스트 가져오기")
+  void getAllRecipe() {
+    //given
+    Pageable pageable = Pageable.ofSize(20);
 
-        when(recipeSearchRepository.findAll(pageable))
-                .thenReturn(new PageImpl<>(recipeDocuments));
-        when(userRepository.findById(any()))
-            .thenReturn(Optional.of(new User()));
+    when(recipeSearchRepository.findAll(pageable))
+        .thenReturn(new PageImpl<>(recipeDocuments));
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(new User()));
 
-        //when
-        Page<RecipeGetListDto> allRecipe = recipeService.getAllRecipe(pageable);
+    //when
+    Page<RecipeGetListDto> allRecipe = recipeService.getAllRecipe(pageable);
 
-        //then
-        assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
-        assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
-    }
+    //then
+    assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
+    assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
+  }
 
-    @Test
-    @DisplayName("레시피 상세 내역 가져오기")
-    void getRecipeDetailById() {
-        //given
-        RecipeDocument recipeDocument = RecipeDocument.builder()
-                .id("userId1")
-                .userId(1L)
-                .title("테스트 타이틀 1")
-                .intro("테스트 인트로 1")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl1")
-                .cookingTime("30분")
-                .serving("1인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build();
+  @Test
+  @DisplayName("레시피 상세 내역 가져오기")
+  void getRecipeDetailById() {
+    //given
+    RecipeDocument recipeDocument = RecipeDocument.builder()
+        .id("userId1")
+        .userId(1L)
+        .title("테스트 타이틀 1")
+        .intro("테스트 인트로 1")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl1")
+        .cookingTime("30분")
+        .serving("1인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build();
 
-        when(recipeSearchRepository.findById(any()))
-                .thenReturn(Optional.of(recipeDocument));
-        when(userRepository.findById(any()))
-            .thenReturn(Optional.of(new User()));
+    when(recipeSearchRepository.findById(any()))
+        .thenReturn(Optional.of(recipeDocument));
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(new User()));
 
-        //when
-        RecipeGetDetailDto recipeDetailById = recipeService.getRecipeDetailById(any());
+    //when
+    RecipeGetDetailDto recipeDetailById = recipeService.getRecipeDetailById(any());
 
-        //then
-        assertEquals(recipeDetailById.getId(), recipeDocument.getId());
-        assertEquals(recipeDetailById.getUserId(), recipeDocument.getUserId());
-        assertEquals(recipeDetailById.getTitle(), recipeDocument.getTitle());
-        assertEquals(recipeDetailById.getIntro(), recipeDocument.getIntro());
-        assertEquals(recipeDetailById.getIngredient(), recipeDocument.getIngredient());
-        assertEquals(recipeDetailById.getCookingStep(), recipeDocument.getCookingStep());
-        assertEquals(recipeDetailById.getImageUrl(), recipeDocument.getImageUrl());
-        assertEquals(recipeDetailById.getCookingTime(), recipeDocument.getCookingTime());
-        assertEquals(recipeDetailById.getServing(), recipeDocument.getServing());
-        assertEquals(recipeDetailById.getViewCount(), recipeDocument.getViewCount());
-        assertEquals(recipeDetailById.getViewCount(), 1L);
-        assertEquals(recipeDetailById.getCreatedAt(), recipeDocument.getCreatedAt());
-        assertEquals(recipeDetailById.getModifiedAt(), recipeDocument.getModifiedAt());
-        assertEquals(recipeDetailById.getCategory(), recipeDocument.getCategory().getKorean());
-    }
+    //then
+    assertEquals(recipeDetailById.getId(), recipeDocument.getId());
+    assertEquals(recipeDetailById.getUserId(), recipeDocument.getUserId());
+    assertEquals(recipeDetailById.getTitle(), recipeDocument.getTitle());
+    assertEquals(recipeDetailById.getIntro(), recipeDocument.getIntro());
+    assertEquals(recipeDetailById.getIngredient(), recipeDocument.getIngredient());
+    assertEquals(recipeDetailById.getCookingStep(), recipeDocument.getCookingStep());
+    assertEquals(recipeDetailById.getImageUrl(), recipeDocument.getImageUrl());
+    assertEquals(recipeDetailById.getCookingTime(), recipeDocument.getCookingTime());
+    assertEquals(recipeDetailById.getServing(), recipeDocument.getServing());
+    assertEquals(recipeDetailById.getViewCount(), recipeDocument.getViewCount());
+    assertEquals(recipeDetailById.getViewCount(), 1L);
+    assertEquals(recipeDetailById.getCreatedAt(), recipeDocument.getCreatedAt());
+    assertEquals(recipeDetailById.getModifiedAt(), recipeDocument.getModifiedAt());
+    assertEquals(recipeDetailById.getCategory(), recipeDocument.getCategory().getKorean());
+  }
 
-    @Test
-    @DisplayName("레시피 리스트 카테고리로 가져오기")
-    void getRecipeByCategory() {
-        //given
-        Pageable pageable = Pageable.ofSize(20);
+  @Test
+  @DisplayName("레시피 리스트 카테고리로 가져오기")
+  void getRecipeByCategory() {
+    //given
+    Pageable pageable = Pageable.ofSize(20);
 
-        when(recipeSearchRepository.findAllByCategory(RecipeCategory.BREAD, pageable))
-                .thenReturn(new PageImpl<>(recipeDocuments));
-        when(userRepository.findById(any()))
-            .thenReturn(Optional.of(new User()));
+    when(recipeSearchRepository.findAllByCategory(RecipeCategory.BREAD, pageable))
+        .thenReturn(new PageImpl<>(recipeDocuments));
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(new User()));
 
-        //when
-        Page<RecipeGetListDto> allRecipe =
-                recipeService.getRecipeByCategory(RecipeCategory.BREAD, pageable);
+    //when
+    Page<RecipeGetListDto> allRecipe =
+        recipeService.getRecipeByCategory(RecipeCategory.BREAD, pageable);
 
-        //then
-        assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
-        assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
-        assertEquals(allRecipe.getContent().get(0).getTitle(), recipeDocuments.get(0).getTitle());
-    }
+    //then
+    assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
+    assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
+    assertEquals(allRecipe.getContent().get(0).getTitle(), recipeDocuments.get(0).getTitle());
+  }
 
-    @Test
-    @DisplayName("레시피 리스트 타이틀로 가져오기")
-    void getRecipeByTitle() {
-        //given
-        Pageable pageable = Pageable.ofSize(20);
+  @Test
+  @DisplayName("레시피 리스트 타이틀로 가져오기")
+  void getRecipeByTitle() {
+    //given
+    Pageable pageable = Pageable.ofSize(20);
 
-        when(recipeSearchRepository.findAllByTitle("title", pageable))
-                .thenReturn(new PageImpl<>(recipeDocuments));
-        when(userRepository.findById(any()))
-            .thenReturn(Optional.of(new User()));
+    when(recipeSearchRepository.findAllByTitle("title", pageable))
+        .thenReturn(new PageImpl<>(recipeDocuments));
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(new User()));
 
-        //when
-        Page<RecipeGetListDto> allRecipe =
-                recipeService.getRecipeByTitle("title", pageable);
+    //when
+    Page<RecipeGetListDto> allRecipe =
+        recipeService.getRecipeByTitle("title", pageable);
 
-        //then
-        assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
-        assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
-        assertEquals(allRecipe.getContent().get(0).getTitle(), recipeDocuments.get(0).getTitle());
-    }
+    //then
+    assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
+    assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
+    assertEquals(allRecipe.getContent().get(0).getTitle(), recipeDocuments.get(0).getTitle());
+  }
 
-    @Test
-    @DisplayName("레시피 리스트 재료로 가져오기")
-    void getRecipeByIngredient() {
-        //given
-        Pageable pageable = Pageable.ofSize(20);
+  @Test
+  @DisplayName("레시피 리스트 재료로 가져오기")
+  void getRecipeByIngredient() {
+    //given
+    Pageable pageable = Pageable.ofSize(20);
 
-        when(recipeSearchRepository.findAllByIngredient("ingredient", pageable))
-                .thenReturn(new PageImpl<>(recipeDocuments));
-        when(userRepository.findById(any()))
-            .thenReturn(Optional.of(new User()));
+    when(recipeSearchRepository.findAllByIngredient("ingredient", pageable))
+        .thenReturn(new PageImpl<>(recipeDocuments));
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(new User()));
 
-        //when
-        Page<RecipeGetListDto> allRecipe =
-                recipeService.getRecipeByIngredient("ingredient", pageable);
+    //when
+    Page<RecipeGetListDto> allRecipe =
+        recipeService.getRecipeByIngredient("ingredient", pageable);
 
-        //then
-        assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
-        assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
-        assertEquals(allRecipe.getContent().get(0).getTitle(), recipeDocuments.get(0).getTitle());
-    }
+    //then
+    assertEquals(recipeDocuments.size(), allRecipe.getContent().size());
+    assertEquals(allRecipe.getContent().get(0).getClass(), RecipeGetListDto.class);
+    assertEquals(allRecipe.getContent().get(0).getTitle(), recipeDocuments.get(0).getTitle());
+  }
 
-    @Test
-    @DisplayName("레시피 수정하기")
-    void updateRecipe() {
-        //given
-        RecipeUpdateDto recipeUpdateDto = RecipeUpdateDto.builder()
-                .title("수정된 타이틀")
-                .ingredient("수정된 재료")
-                .category(RecipeCategory.ETC)
-                .imagesUrl("수정된 Url")
-                .intro("")
-                .videoUrl("")
-                .cookingStep("수정된 조리 스텝")
-                .cookingTime("수정된 시간")
-                .serving("수정된 양")
-                .build();
+  @Test
+  @DisplayName("레시피 수정하기")
+  void updateRecipe() {
+    //given
+    RecipeUpdateDto recipeUpdateDto = RecipeUpdateDto.builder()
+        .title("수정된 타이틀")
+        .ingredient("수정된 재료")
+        .category(RecipeCategory.ETC)
+        .imagesUrl("수정된 Url")
+        .intro("")
+        .videoUrl("")
+        .cookingStep("수정된 조리 스텝")
+        .cookingTime("수정된 시간")
+        .serving("수정된 양")
+        .build();
 
-        User user = User.builder()
-                .name("테스트이름")
-                .build();
+    User user = User.builder()
+        .name("테스트이름")
+        .build();
 
-        RecipeDocument recipeDocument = RecipeDocument.builder()
-                .id("userId1")
-                .userId(user.getId())
-                .title("테스트 타이틀 1")
-                .intro("테스트 인트로 1")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl1")
-                .thumbnailUrl("testThumbnailUrl")
-                .cookingTime("30분")
-                .serving("1인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build();
+    RecipeDocument recipeDocument = RecipeDocument.builder()
+        .id("userId1")
+        .userId(user.getId())
+        .title("테스트 타이틀 1")
+        .intro("테스트 인트로 1")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl1")
+        .thumbnailUrl("testThumbnailUrl")
+        .cookingTime("30분")
+        .serving("1인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build();
 
-        Principal principal = new UsernamePasswordAuthenticationToken(
-                "updateRecipe@test.com", null);
+    Principal principal = new UsernamePasswordAuthenticationToken(
+        "updateRecipe@test.com", null);
 
-        when(userRepository.findByEmail("updateRecipe@test.com"))
-                .thenReturn(Optional.of(user));
+    when(userRepository.findByEmail("updateRecipe@test.com"))
+        .thenReturn(Optional.of(user));
 
-        when(recipeSearchRepository.findById(any()))
-                .thenReturn(Optional.of(recipeDocument));
+    when(recipeSearchRepository.findById(any()))
+        .thenReturn(Optional.of(recipeDocument));
 
-        //when
-        recipeService.updateRecipe(principal, recipeDocument.getId(), recipeUpdateDto,
-                Collections.singletonList(mock(MultipartFile.class)), mock(MultipartFile.class));
+    //when
+    recipeService.updateRecipe(principal, recipeDocument.getId(), recipeUpdateDto,
+        Collections.singletonList(mock(MultipartFile.class)), mock(MultipartFile.class));
 
-        //then
-        assertEquals(recipeDocument.getTitle(), recipeUpdateDto.getTitle());
-    }
+    //then
+    assertEquals(recipeDocument.getTitle(), recipeUpdateDto.getTitle());
+  }
 
-    @Test
-    @DisplayName("레시피 삭제하기")
-    void deleteRecipe() {
-        //given
-        User user = User.builder()
-                .name("테스트이름")
-                .build();
+  @Test
+  @DisplayName("레시피 삭제하기 성공")
+  void deleteRecipe_SUCCESS() {
+    //given
+    User user = User.builder()
+        .name("테스트이름")
+        .build();
 
-        RecipeDocument recipeDocument = RecipeDocument.builder()
-                .id("recipdId")
-                .userId(user.getId())
-                .title("테스트 타이틀 1")
-                .intro("테스트 인트로 1")
-                .ingredient("재료1, 재료2, 재료3")
-                .cookingStep("테스트 쿠킹 스텝")
-                .imageUrl("testimageurl1")
-                .cookingTime("30분")
-                .serving("1인분")
-                .viewCount(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .category(RecipeCategory.BREAD)
-                .build();
+    RecipeDocument recipeDocument = RecipeDocument.builder()
+        .id("recipdId")
+        .userId(user.getId())
+        .title("테스트 타이틀 1")
+        .intro("테스트 인트로 1")
+        .ingredient("재료1, 재료2, 재료3")
+        .cookingStep("테스트 쿠킹 스텝")
+        .imageUrl("testimageurl1")
+        .cookingTime("30분")
+        .serving("1인분")
+        .viewCount(0L)
+        .createdAt(LocalDateTime.now())
+        .modifiedAt(LocalDateTime.now())
+        .category(RecipeCategory.BREAD)
+        .build();
 
-        Principal principal = new UsernamePasswordAuthenticationToken(
-                "updateRecipe@test.com", null);
+    Principal principal = new UsernamePasswordAuthenticationToken(
+        "updateRecipe@test.com", null);
 
-        when(userRepository.findByEmail("updateRecipe@test.com"))
-                .thenReturn(Optional.of(user));
+    when(userRepository.findByEmail("updateRecipe@test.com"))
+        .thenReturn(Optional.of(user));
 
-        when(recipeSearchRepository.findById(any()))
-                .thenReturn(Optional.of(recipeDocument));
+    when(recipeSearchRepository.findById(any()))
+        .thenReturn(Optional.of(recipeDocument));
 
+    //when
+    recipeService.deleteRecipe(principal, recipeDocument.getId());
 
-        //when
-        recipeService.deleteRecipe(principal, recipeDocument.getId());
+    //then
+    verify(recipeSearchRepository, times(1))
+        .delete(any(RecipeDocument.class));
+  }
 
-        //then
-        verify(recipeSearchRepository, times(1))
-                .delete(any(RecipeDocument.class));
-    }
+  @Test
+  @DisplayName("레시피 삭제하기 성공 - 어드민 계정")
+  void deleteRecipe_SUCCESS_Admin_Account() {
+    //given
+    User adminAccount = mock(User.class);
+
+    RecipeDocument recipeDocument = mock(RecipeDocument.class);
+
+    Principal principal = new UsernamePasswordAuthenticationToken(
+        "updateRecipe@test.com", null);
+
+    when(userRepository.findByEmail(any()))
+        .thenReturn(Optional.of(adminAccount));
+    when(recipeSearchRepository.findById(any()))
+        .thenReturn(Optional.of(recipeDocument));
+
+    when(recipeDocument.getUserId()).thenReturn(1L);
+    when(adminAccount.getId()).thenReturn(2L);
+
+    when(adminAccount.getRoles()).thenReturn(RoleType.ADMIN);
+
+    when(recipeDocument.getThumbnailUrl()).thenReturn("");
+    when(recipeDocument.getImageUrl()).thenReturn("");
+
+    //when
+    recipeService.deleteRecipe(principal, recipeDocument.getId());
+
+    //then
+    verify(recipeSearchRepository, times(1))
+        .delete(any(RecipeDocument.class));
+  }
+
+  @Test
+  @DisplayName("레시피 삭제 실패 - 레시피의 유저 이외 유저가 삭제 시도")
+  void deleteRecipe_FAIL_NO_PERMISSION() {
+    //given
+    User noPermissionUser = mock(User.class);
+
+    RecipeDocument recipeDocument = mock(RecipeDocument.class);
+
+    Principal principal = new UsernamePasswordAuthenticationToken(
+        "updateRecipe@test.com", null);
+
+    when(userRepository.findByEmail(any()))
+        .thenReturn(Optional.of(noPermissionUser));
+    when(recipeSearchRepository.findById(any()))
+        .thenReturn(Optional.of(recipeDocument));
+
+    when(recipeDocument.getUserId()).thenReturn(1L);
+    when(noPermissionUser.getId()).thenReturn(2L);
+
+    when(noPermissionUser.getRoles()).thenReturn(RoleType.USER);
+
+    //when
+    CustomException customException = assertThrows(CustomException.class,
+        () ->recipeService.deleteRecipe(principal, recipeDocument.getId()));
+
+    //then
+    assertEquals(ErrorCode.NO_PERMISSION, customException.getErrorCode());
+  }
 
 }


### PR DESCRIPTION
ADMIN 계정 - 레시피 삭제 권한 부여
---
- ADMIN 계정으로는 여러 유저의 레시피를 삭제할 수 있도록 로직 수정
- 코드 정렬

수정된 부분 - RecipeService의 161 ~ 164번 줄
---
!user.getRoles().equals(RoleType.ADMIN), 어드민 계정인지 확인하는 로직이 추가됨

    if (!Objects.equals(user.getId(), recipeDocument.getUserId()) &&
            !user.getRoles().equals(RoleType.ADMIN)) {
          throw new CustomException(ErrorCode.NO_PERMISSION);
    }
    
테스트코드
---
- ADMIN 계정으로 하면 레시피의 유저 ID가 아니어도 삭제가 가능한 테스트 코드 추가
- ADMIN 계정이 아니고 다른 유저라면 삭제가 안 되는 테스트 코드 추가