### PR TITLE
hotfix/LikesDto 수정

### DIFF
--- a/src/main/java/kr/zb/nengtul/likes/domain/dto/LikesDto.java
+++ b/src/main/java/kr/zb/nengtul/likes/domain/dto/LikesDto.java
@@ -16,6 +16,10 @@ public class LikesDto {
 
   private String thumbnailUrl;
 
+  private String recipeUserNickName;
+
+  private Long likeCount;
+
   private LocalDateTime createdAt;
 
 }

--- a/src/main/java/kr/zb/nengtul/likes/service/LikesService.java
+++ b/src/main/java/kr/zb/nengtul/likes/service/LikesService.java
@@ -69,12 +69,17 @@ public class LikesService {
                   .thumbnailUrl("")
                   .build());
 
+          User recipeUser = userRepository.findById(recipeDocument.getUserId())
+              .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
           return LikesDto.builder()
               .id(likes.getId())
               .createdAt(likes.getCreatedAt())
               .recipeId(recipeDocument.getId())
               .title(recipeDocument.getTitle())
               .thumbnailUrl(recipeDocument.getThumbnailUrl())
+              .likeCount(likesRepository.countByRecipeId(recipeDocument.getId()))
+              .recipeUserNickName(recipeUser.getNickname())
               .build();
         });
   }

--- a/src/test/java/kr/zb/nengtul/likes/service/LikesServiceTest.java
+++ b/src/test/java/kr/zb/nengtul/likes/service/LikesServiceTest.java
@@ -132,6 +132,12 @@ class LikesServiceTest {
     when(recipeSearchRepository.findById(any()))
         .thenReturn(Optional.of(recipeDocument));
 
+    when(userRepository.findById(any()))
+        .thenReturn(Optional.of(User.builder().nickname("테스트 닉네임").build()));
+
+    when(likesRepository.countByRecipeId(any()))
+        .thenReturn(50L);
+
     Principal principal = new UsernamePasswordAuthenticationToken(
         "test@test.com", null);
 
@@ -144,6 +150,8 @@ class LikesServiceTest {
     assertEquals(likesDto.getTitle(), recipeDocument.getTitle());
     assertEquals(likesDto.getThumbnailUrl(), recipeDocument.getThumbnailUrl());
     assertEquals(likesDto.getRecipeId(), recipeDocument.getId());
+    assertEquals(likesDto.getRecipeUserNickName(), "테스트 닉네임");
+    assertEquals(likesDto.getLikeCount(), 50);
   }
 
   @Test


### PR DESCRIPTION
LikesDto 파라미터 추가
---
- 프론트엔트 요청으로 게시물의 좋아요 수, 게시물 유저의 닉네임 추가

테스트 코드
---
좋아요 조회 시 좋아요 수, 닉네임 확인하는 로직 추가