### PR TITLE
Feature/blacklisttoken

### DIFF
--- a/src/main/java/kr/zb/nengtul/NengtulApplication.java
+++ b/src/main/java/kr/zb/nengtul/NengtulApplication.java
@@ -1,5 +1,7 @@
 package kr.zb.nengtul;
 
+import kr.zb.nengtul.auth.repository.BlacklistTokenRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -18,7 +20,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     "s3bucket", "kr.zb.nengtul"
 })
 public class NengtulApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(NengtulApplication.class, args);
     }

--- a/src/main/java/kr/zb/nengtul/auth/controller/AuthController.java
+++ b/src/main/java/kr/zb/nengtul/auth/controller/AuthController.java
@@ -1,4 +1,4 @@
-package kr.zb.nengtul.auth;
+package kr.zb.nengtul.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/kr/zb/nengtul/auth/entity/BlacklistToken.java
+++ b/src/main/java/kr/zb/nengtul/auth/entity/BlacklistToken.java
@@ -1,0 +1,31 @@
+package kr.zb.nengtul.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class BlacklistToken {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull
+  private String email;
+
+  @NotNull
+  private String blacklistToken;
+}

--- a/src/main/java/kr/zb/nengtul/auth/repository/BlacklistTokenRepository.java
+++ b/src/main/java/kr/zb/nengtul/auth/repository/BlacklistTokenRepository.java
@@ -1,0 +1,9 @@
+package kr.zb.nengtul.auth.repository;
+
+import kr.zb.nengtul.auth.entity.BlacklistToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlacklistTokenRepository extends JpaRepository<BlacklistToken, Long> {
+
+  BlacklistToken findByBlacklistToken(String blacklistToken);
+}

--- a/src/main/java/kr/zb/nengtul/auth/sevice/AuthService.java
+++ b/src/main/java/kr/zb/nengtul/auth/sevice/AuthService.java
@@ -1,0 +1,24 @@
+package kr.zb.nengtul.auth.sevice;
+
+import kr.zb.nengtul.auth.repository.BlacklistTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final BlacklistTokenRepository blacklistTokenRepository;
+
+
+  //매월 1일 0시 0분 0초에 블랙리스트에 등록된 모든 토큰 삭제
+  @Scheduled(cron = "0 0 0 1 * ?")
+  public void cleanBlacklist() {
+    blacklistTokenRepository.deleteAll();
+    log.debug("** Clear " + blacklistTokenRepository.count() + "BlacklistToken **");
+  }
+
+}

--- a/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
+++ b/src/main/java/kr/zb/nengtul/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package kr.zb.nengtul.global.config;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.zb.nengtul.auth.repository.BlacklistTokenRepository;
 import kr.zb.nengtul.global.filter.CustomJsonUsernamePasswordAuthenticationFilter;
 import kr.zb.nengtul.global.handler.LoginFailureHandler;
 import kr.zb.nengtul.global.handler.LoginSuccessHandler;
@@ -48,6 +49,7 @@ public class SecurityConfig {
 
   private final CustomUserDetailService customUserDetailService;
   private final JwtTokenProvider jwtTokenProvider;
+  private final BlacklistTokenRepository blacklistTokenRepository;
   private final UserRepository userRepository;
   private final ObjectMapper objectMapper;
   private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
@@ -173,7 +175,7 @@ public class SecurityConfig {
   @Bean
   public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
     return new JwtAuthenticationProcessingFilter(
-        jwtTokenProvider, userRepository);
+        jwtTokenProvider, userRepository, blacklistTokenRepository);
   }
 
   //cors 설정

--- a/src/main/java/kr/zb/nengtul/global/exception/ErrorCode.java
+++ b/src/main/java/kr/zb/nengtul/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
   ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 이메일입니다."),
   ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 닉네임입니다."),
   ALREADY_EXIST_PHONENUMBER(HttpStatus.BAD_REQUEST, "이미 등록 되어있는 휴대폰 번호입니다."),
+  ALREADY_LOGOUT_TOKEN(HttpStatus.BAD_REQUEST, "로그아웃된 회원입니다. 로그인을 다시 해주세요."),
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
   ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료된 사용자입니다."),
   WRONG_VERIFY_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다."),

--- a/src/main/java/kr/zb/nengtul/global/util/HeaderUtil.java
+++ b/src/main/java/kr/zb/nengtul/global/util/HeaderUtil.java
@@ -1,0 +1,42 @@
+package kr.zb.nengtul.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class HeaderUtil {
+  private final static String HEADER_AUTHORIZATION = "Authorization";
+  private final static String HEADER_REFRESH_TOKEN = "RefreshToken";
+  private final static String TOKEN_PREFIX = "Bearer ";
+
+  public static String getAccessToken(HttpServletRequest request) {
+    String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+
+    if (headerValue == null) {
+      return null;
+    }
+
+    if (headerValue.startsWith(TOKEN_PREFIX)) {
+      return headerValue.substring(TOKEN_PREFIX.length());
+    }
+
+    return null;
+  }
+
+  public static String getRefreshToken(HttpServletRequest request) {
+    String headerValue = request.getHeader(HEADER_REFRESH_TOKEN);
+
+    if (headerValue == null) {
+      return null;
+    }
+
+    if (headerValue.startsWith(TOKEN_PREFIX)) {
+      return headerValue.substring(TOKEN_PREFIX.length());
+    }
+
+    return null;
+  }
+
+  public static void setHeaderRefreshToken(HttpServletResponse response, String value) {
+    response.setHeader(HEADER_REFRESH_TOKEN, value);
+  }
+}

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -103,7 +103,7 @@ public class UserController {
 
   //로그아웃
   @Operation(summary = "로그아웃", description = "사용하던 토큰을 블랙리스트로 등록해 다시 사용할 수 없게 지정합니다.")
-  @DeleteMapping("/logout")
+  @PostMapping("/logout")
   public ResponseEntity<Void> logout(HttpServletRequest request, Principal principal) {
     userService.logout(request,principal);
     return ResponseEntity.ok(null);

--- a/src/main/java/kr/zb/nengtul/user/controller/UserController.java
+++ b/src/main/java/kr/zb/nengtul/user/controller/UserController.java
@@ -3,6 +3,7 @@ package kr.zb.nengtul.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import kr.zb.nengtul.user.domain.dto.UserDetailDto;
@@ -97,6 +98,14 @@ public class UserController {
   @DeleteMapping("/detail")
   public ResponseEntity<Void> quitUser(Principal principal) {
     userService.quitUser(principal);
+    return ResponseEntity.ok(null);
+  }
+
+  //로그아웃
+  @Operation(summary = "로그아웃", description = "사용하던 토큰을 블랙리스트로 등록해 다시 사용할 수 없게 지정합니다.")
+  @DeleteMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletRequest request, Principal principal) {
+    userService.logout(request,principal);
     return ResponseEntity.ok(null);
   }
 

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -9,15 +9,20 @@ import static kr.zb.nengtul.global.exception.ErrorCode.NOT_FOUND_USER;
 import static kr.zb.nengtul.global.exception.ErrorCode.NO_CONTENT;
 import static kr.zb.nengtul.global.exception.ErrorCode.WRONG_VERIFY_CODE;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.Optional;
+import kr.zb.nengtul.auth.entity.BlacklistToken;
+import kr.zb.nengtul.auth.repository.BlacklistTokenRepository;
 import kr.zb.nengtul.comment.domain.entity.Comment;
 import kr.zb.nengtul.comment.domain.respository.CommentRepository;
 import kr.zb.nengtul.comment.replycomment.domain.entity.ReplyComment;
 import kr.zb.nengtul.comment.replycomment.domain.repository.ReplyCommentRepository;
 import kr.zb.nengtul.global.exception.CustomException;
 import kr.zb.nengtul.global.exception.ErrorCode;
+import kr.zb.nengtul.global.util.HeaderUtil;
 import kr.zb.nengtul.likes.domain.repository.LikesRepository;
 import kr.zb.nengtul.notice.domain.entity.Notice;
 import kr.zb.nengtul.notice.domain.repository.NoticeRepository;
@@ -64,6 +69,7 @@ public class UserService {
   private final CommentRepository commentRepository;
 
   private final UserRepository userRepository;
+  private final BlacklistTokenRepository blacklistTokenRepository;
   private final PasswordEncoder passwordEncoder;
   private final MailgunClient mailgunClient;
   private final AmazonS3Service amazonS3Service;
@@ -137,7 +143,7 @@ public class UserService {
       notice.setUser(quitUser);
       noticeRepository.save(notice);
     }
-    for(RecipeDocument recipeDocument : recipeSearchRepository.findAllByUserId(user.getId())){
+    for (RecipeDocument recipeDocument : recipeSearchRepository.findAllByUserId(user.getId())) {
       recipeDocument.setUserId(quitUser.getId());
       recipeSearchRepository.save(recipeDocument);
     }
@@ -285,7 +291,7 @@ public class UserService {
       throw new CustomException(ErrorCode.NOT_EXIST_USER_ATTRIBUTE_IN_WEBSOCKET_SESSION);
     }
     return (String) Objects.requireNonNull(accessor.getSessionAttributes())
-            .get("user");
+        .get("user");
   }
 
   @Transactional(readOnly = true)
@@ -304,8 +310,27 @@ public class UserService {
         .point(user.getPoint())
         .myRecipe(recipeSearchRepository.countByUserId(user.getId()))
         .likeRecipe(likesRepository.countByUserId(user.getId()))
-        .shareList(shareBoardRepository.countByUserIdAndClosed(user.getId(), false)) //거래중인 게시물 개수만 확인
+        .shareList(
+            shareBoardRepository.countByUserIdAndClosed(user.getId(), false)) //거래중인 게시물 개수만 확인
         .build();
+  }
+
+  @Transactional
+  public void logout(HttpServletRequest request, Principal principal) {
+    String token = HeaderUtil.getAccessToken(request);
+
+    // 이미 블랙리스트에 등록된 토큰인 경우 삭제하도록 처리
+    BlacklistToken existingToken = blacklistTokenRepository.findByBlacklistToken(token);
+    if (existingToken != null) {
+      blacklistTokenRepository.delete(existingToken);
+    }
+
+    // AccessToken을 블랙리스트에 추가
+    BlacklistToken blacklistToken = BlacklistToken.builder()
+        .email(principal.getName())
+        .blacklistToken(token)
+        .build();
+    blacklistTokenRepository.save(blacklistToken);
   }
 
 }

--- a/src/main/java/kr/zb/nengtul/user/service/UserService.java
+++ b/src/main/java/kr/zb/nengtul/user/service/UserService.java
@@ -13,7 +13,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.Optional;
 import kr.zb.nengtul.auth.entity.BlacklistToken;
 import kr.zb.nengtul.auth.repository.BlacklistTokenRepository;
 import kr.zb.nengtul.comment.domain.entity.Comment;
@@ -317,13 +316,8 @@ public class UserService {
 
   @Transactional
   public void logout(HttpServletRequest request, Principal principal) {
+    //헤더에서 토큰 가져옴
     String token = HeaderUtil.getAccessToken(request);
-
-    // 이미 블랙리스트에 등록된 토큰인 경우 삭제하도록 처리
-    BlacklistToken existingToken = blacklistTokenRepository.findByBlacklistToken(token);
-    if (existingToken != null) {
-      blacklistTokenRepository.delete(existingToken);
-    }
 
     // AccessToken을 블랙리스트에 추가
     BlacklistToken blacklistToken = BlacklistToken.builder()
@@ -331,6 +325,8 @@ public class UserService {
         .blacklistToken(token)
         .build();
     blacklistTokenRepository.save(blacklistToken);
+
+    System.out.println(blacklistTokenRepository.count());
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
     secret-key: ${spring.jwt.secret-key}
 
     access:
-      expiration: 180000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
+      expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
       header: Authorization
 
     refresh:


### PR DESCRIPTION
로그아웃 & 블랙리스트 토큰 기능 구현

헤더에 있는 토큰 String 형태로 가져오기 위해 HeaderUtil 정의

blacklist_token 은 id(pk)와 blacklisttoken, email 로 구성

블랙리스트에 등록된 토큰 매월 1일 0시 0분 0초에 초기화(db용량 차지하기 때문에 스케쥴링으로 삭제 처리)

필터에서 토큰 처리시 블랙리스트에 등록된 요청이 들어온다면 400오류와 함께 들어오지 못하게 처리(CustomException 정의)
![image](https://github.com/nengtul/nengtul-backend/assets/101981639/f27f140f-aed3-441c-ba97-d2a3075fca17)


토큰 테스트로 인하여 3분으로 적용했었는데 다시 1시간으로 정정

