### PR TITLE
feature/Update_FavoriteEntity_FetchType

### DIFF
--- a/src/main/java/kr/zb/nengtul/favorite/domain/entity/Favorite.java
+++ b/src/main/java/kr/zb/nengtul/favorite/domain/entity/Favorite.java
@@ -28,7 +28,7 @@ public class Favorite {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "publisher_id")
     private User publisher;
 

--- a/src/main/java/kr/zb/nengtul/favorite/domain/repository/FavoriteRepository.java
+++ b/src/main/java/kr/zb/nengtul/favorite/domain/repository/FavoriteRepository.java
@@ -1,21 +1,22 @@
 package kr.zb.nengtul.favorite.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kr.zb.nengtul.favorite.domain.entity.Favorite;
 import kr.zb.nengtul.user.domain.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
-    Page<Favorite> findAllByUserId(Long userId, Pageable pageable);
+  @EntityGraph(attributePaths = "publisher", type = EntityGraph.EntityGraphType.LOAD)
+  Page<Favorite> findAllByUserId(Long userId, Pageable pageable);
 
-    Optional<Favorite> findByUserIdAndPublisherId(Long userId, Long publisherId);
+  Optional<Favorite> findByUserIdAndPublisherId(Long userId, Long publisherId);
 
-    List<Favorite> findByPublisher(User publisher);
+  List<Favorite> findByPublisher(User publisher);
 }


### PR DESCRIPTION
Favorite
---
즐겨찾기에서 조회할 때 모든 로직에서 publisher를 조회했기 때문에 패치 타입을 Eager로 했으나, 프론트엔드에서 요청하는 부분을 추가하다보니 즐겨찾기를 조회하는 부분이 많아져서 publisher의 패치타입을 Lazy로 변경하고 publisher를 조회하는 부분에만 Repository에 EntityGraph를 사용하여 수정하였습니다.