### PR TITLE
fix/chat: 채팅방 나갈시, 조회 api 오류 fix

### DIFF
--- a/src/main/java/kr/zb/nengtul/chat/domain/ConnectedChatRoom.java
+++ b/src/main/java/kr/zb/nengtul/chat/domain/ConnectedChatRoom.java
@@ -31,11 +31,17 @@ public class ConnectedChatRoom {
     @JoinColumn(name = "user_id")
     private User userId;
 
+    private boolean leaveRoom;
+
     public void setChatRoom(ChatRoom chatRoom) {
         this.chatRoom = chatRoom;
     }
 
-    public User getUser(){
+    public void setLeaveRoom(boolean leaveRoom) {
+        this.leaveRoom = leaveRoom;
+    }
+
+    public User getUser() {
         return this.userId;
     }
 }

--- a/src/main/java/kr/zb/nengtul/chat/domain/sql/chat.sql
+++ b/src/main/java/kr/zb/nengtul/chat/domain/sql/chat.sql
@@ -11,6 +11,7 @@ CREATE TABLE connected_chat_room
     id      BIGINT AUTO_INCREMENT PRIMARY KEY,
     room_id BIGINT,
     user_id BIGINT,
+    leave_room BOOLEAN,
 
     FOREIGN KEY (room_id) REFERENCES chat_room (id),
     FOREIGN KEY (user_id) REFERENCES user (id)

--- a/src/main/java/kr/zb/nengtul/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/kr/zb/nengtul/chat/repository/ChatRoomRepository.java
@@ -14,5 +14,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByRoomId(String roomId);
 
     @EntityGraph(value = "chatRoomWithShareBoardAndConnectedChatRoomsAndChtList")
-    List<ChatRoom> findByConnectedChatRoomsUserIdOrderByCreatedAtDesc(User user);
+    List<ChatRoom> findByConnectedChatRoomsUserIdAndConnectedChatRoomsLeaveRoomIsFalseOrderByChatListCreatedAtDesc(User user);
+
+
 }


### PR DESCRIPTION
원인 :
- 채팅방 조회 api 에서 상대방 닉네임을 필요로함
- 채팅방을 나갈시 ConnectedChatRoom 에서 지워짐
- 채팅방에 상대방에 대한 정보가 지워져서 추적이 불가함

방안 1 : "나간 유저" 라는 defualt 값을 줌
방안 2 : 채팅방을 나가더라도 추적이 가능하도록 정보를 남겨둠

2번 방안으로 진행했습니다.

ConnectedChatRoom (수정):
- 채팅방을 나갔음을 의미하는 boolean 값 추가(leaveRoom)
- sql문 수정

ChatRoomRepository:
- user가 속한 채팅방 목록을 불러옴
- leaveRoom이 false인것만 불러옴
- 가장 최근 채팅순으로 불러옴

ChatRoomService : 나가기 로직 수정
- delete없이 leaveRoom을 true로 업데이트 하는것으로 나감을 의미함
- 연결된 유저들 모두 leaveRoom이 true이면, 채팅방과 채팅, 연결기록을 일괄 삭제함