### PR TITLE
fix/chat: 쿼리문 변경

### DIFF
--- a/src/main/java/kr/zb/nengtul/chat/service/ChatRoomService.java
+++ b/src/main/java/kr/zb/nengtul/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package kr.zb.nengtul.chat.service;
 
 import java.util.List;
+import java.util.Set;
 import kr.zb.nengtul.chat.domain.ChatRoom;
 import kr.zb.nengtul.chat.domain.ConnectedChatRoom;
 import kr.zb.nengtul.chat.repository.ChatRepository;
@@ -40,14 +41,25 @@ public class ChatRoomService {
     @Transactional
     public ChatRoom findOrCreateRoom(User user1, User user2, ShareBoard shareBoard) {
 
-        return connectedChatRoomRepository.findChatRoomByUsersAndShareBoard(user1, user2,
+        ChatRoom chatRoom = connectedChatRoomRepository.findChatRoomByUsersAndShareBoard(user1,
+                        user2,
                         shareBoard.getId())
                 .orElseGet(() -> {
-                    ChatRoom chatRoom = createChatRoom(shareBoard);
-                    joinRoom(user1, chatRoom);
-                    joinRoom(user2, chatRoom);
-                    return chatRoom;
+                    ChatRoom newRoom = createChatRoom(shareBoard);
+                    joinRoom(user1, newRoom);
+                    joinRoom(user2, newRoom);
+                    return newRoom;
                 });
+
+        Set<ConnectedChatRoom> connectedChatRooms = chatRoom.getConnectedChatRooms();
+
+        for (ConnectedChatRoom connectedChatRoom : connectedChatRooms) {
+            connectedChatRoom.setLeaveRoom(false);
+        }
+
+        connectedChatRoomRepository.saveAll(connectedChatRooms);
+
+        return chatRoom;
     }
 
     @Transactional


### PR DESCRIPTION
원인 :
- 나간 유저가 있더라도 기존 채팅방을 사용
- 그러나 채팅방 조회시, 나간 채팅방이기 때문에 보이지 않는 현상 발생

ChatRoomService - findOrCreateRoom
- 다시 연결을 이어주도록 로직 수정